### PR TITLE
Add ability to only build some docker images

### DIFF
--- a/scripts/build-docker-base.sh
+++ b/scripts/build-docker-base.sh
@@ -11,7 +11,15 @@ $LSTORE_SCRIPT_BASE/generate-docker-base.sh
 
 cd $LSTORE_SCRIPT_BASE/docker/base
 STATUS=""
-for DISTRO in */; do
+
+# Parse comand line
+DISTROS=( "$@" )
+if [ ${#DISTROS[@]} -eq 0 ]; then
+    DISTROS=( */ )
+fi
+DISTROS=( "${DISTROS[@]%/}" )
+
+for DISTRO in "${DISTROS[@]}"; do
     note "Processing $(basename $DISTRO)"
     docker build --force-rm=true --rm=true \
         -t "lstore/builder:$(basename $DISTRO)" "$DISTRO" || \


### PR DESCRIPTION
Now that we're adding more and more supported distributions, give
developers the ability to only build a subset.
