### PR TITLE
Make builds return correct error messages

### DIFF
--- a/scripts/build-docker-base.sh
+++ b/scripts/build-docker-base.sh
@@ -18,16 +18,25 @@ if [ ${#DISTROS[@]} -eq 0 ]; then
     DISTROS=( */ )
 fi
 DISTROS=( "${DISTROS[@]%/}" )
+SUCCESS=0
 
 for DISTRO in "${DISTROS[@]}"; do
     note "Processing $(basename $DISTRO)"
     docker build --force-rm=true --rm=true \
-        -t "lstore/builder:$(basename $DISTRO)" "$DISTRO" || \
-        STATUS="${STATUS}"$'\n'"Failed to build $DISTRO" && \
+        -t "lstore/builder:$(basename $DISTRO)" "$DISTRO"
+    if [ $? -ne 0 ]; then
+        SUCCESS=1
+        STATUS="${STATUS}"$'\n'"Failed to build $DISTRO"
+    else
         STATUS="${STATUS}"$'\n'"Successfully built $DISTRO"
+    fi
 done
 if [ ! -z "$STATUS" ]; then
-    note "$STATUS"
+    if [ $SUCCESS -eq 0 ]; then
+        note "$STATUS"
+    else
+        fatal "$STATUS"
+    fi
 else
     fatal "Nothing was built?"
 fi


### PR DESCRIPTION
Ensure the error code propagates out of the script so jenkins knows
how to handle it
