### PR TITLE
Add CMake to docker builds

### DIFF
--- a/scripts/generate-docker-base.sh
+++ b/scripts/generate-docker-base.sh
@@ -119,5 +119,14 @@ FROM $FROM
 MAINTAINER http://lstore.org
 $GLOBAL_INSTALL
 $PACKAGE_INSTALL
+RUN cd /tmp && \
+    git clone https://github.com/Kitware/CMake.git && \
+    cd CMake && \
+    git checkout v3.5.1 && \
+    ./bootstrap && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf CMake
 EOF
 done


### PR DESCRIPTION
Instead of pulling cmake tarballs, build and install cmake from source
and add to the docker image
