### PR TITLE
Rename toolbox functions

### DIFF
--- a/sort.py
+++ b/sort.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+sort = {}
+regex = re.compile(r'TBX_API \w* \*?(\w*)\(.*')
+for line in sys.stdin.readlines():
+    result = regex.match(line)
+    if not result:
+        sort[line] = line
+    else:
+        sort[result.group(1)] = line
+
+for k in sorted(sort.keys()):
+    sys.stdout.write(sort[k])

--- a/src/gop/gop.c
+++ b/src/gop/gop.c
@@ -260,7 +260,7 @@ int _gop_completed_successfully(op_generic_t *g)
     int status;
 
     if (gop_get_type(g) == Q_TYPE_QUE) {
-        status = tbx_stack_size(g->q->failed);
+        status = tbx_stack_count(g->q->failed);
         status = (status == 0) ? g->base.status.op_status : OP_STATE_FAILURE;
     } else {
         status = g->base.status.op_status;
@@ -343,7 +343,7 @@ int gop_tasks_failed(op_generic_t *g)
 
     lock_gop(g);
     if (gop_get_type(g) == Q_TYPE_QUE) {
-        nf = tbx_stack_size(g->q->failed);
+        nf = tbx_stack_count(g->q->failed);
     } else {
         nf = (g->base.status.op_status == OP_STATE_SUCCESS) ? 0 : 1;
     }
@@ -362,7 +362,7 @@ int gop_tasks_finished(op_generic_t *g)
 
     lock_gop(g);
     if (gop_get_type(g) == Q_TYPE_QUE) {
-        nf = tbx_stack_size(g->q->finished);
+        nf = tbx_stack_count(g->q->finished);
     } else {
         nf = (g->base.state == 1) ? 1 : 0;
     }
@@ -522,7 +522,7 @@ int gop_will_block(op_generic_t *g)
 
     lock_gop(g);
     if (gop_get_type(g) == Q_TYPE_QUE) {
-        if ((tbx_stack_size(g->q->finished) == 0) && (g->q->nleft > 0)) status = 1;
+        if ((tbx_stack_count(g->q->finished) == 0) && (g->q->nleft > 0)) status = 1;
     } else {
         if (g->base.state == 0) status = 1;
     }
@@ -544,8 +544,8 @@ op_generic_t *gop_waitany(op_generic_t *g)
     lock_gop(g);
 
     if (gop_get_type(g) == Q_TYPE_QUE) {
-        log_printf(15, "sync_exec_que_check gid=%d stack_size=%d started_exec=%d\n", gop_id(g), tbx_stack_size(g->q->opque->qd.list), g->base.started_execution);
-        if ((tbx_stack_size(g->q->opque->qd.list) == 1) && (g->base.started_execution == 0)) {  //** See if we can directly exec
+        log_printf(15, "sync_exec_que_check gid=%d stack_size=%d started_exec=%d\n", gop_id(g), tbx_stack_count(g->q->opque->qd.list), g->base.started_execution);
+        if ((tbx_stack_count(g->q->opque->qd.list) == 1) && (g->base.started_execution == 0)) {  //** See if we can directly exec
             g->base.started_execution = 1;
             cb = (callback_t *)tbx_stack_pop(g->q->opque->qd.list);
             gop = (op_generic_t *)cb->priv;
@@ -606,9 +606,9 @@ int gop_waitall(op_generic_t *g)
     lock_gop(g);
 
     if (gop_get_type(g) == Q_TYPE_QUE) {
-        log_printf(15, "sync_exec_que_check gid=%d stack_size=%d started_exec=%d\n", gop_id(g), tbx_stack_size(g->q->opque->qd.list), g->base.started_execution);
+        log_printf(15, "sync_exec_que_check gid=%d stack_size=%d started_exec=%d\n", gop_id(g), tbx_stack_count(g->q->opque->qd.list), g->base.started_execution);
 
-        if ((tbx_stack_size(g->q->opque->qd.list) == 1) && (g->base.started_execution == 0)) {  //** See if we can directly exec
+        if ((tbx_stack_count(g->q->opque->qd.list) == 1) && (g->base.started_execution == 0)) {  //** See if we can directly exec
             log_printf(15, "sync_exec_que -- waiting for gid=%d to complete\n", gop_id(g));
             cb = (callback_t *)tbx_stack_pop(g->q->opque->qd.list);
             g2 = (op_generic_t *)cb->priv;

--- a/src/gop/gop.c
+++ b/src/gop/gop.c
@@ -151,7 +151,7 @@ void gop_dummy_destroy()
     apr_thread_join(&tstat, gd_thread);
 
     //** Clean up;
-    tbx_free_stack(gd_stack, 0);
+    tbx_stack_free(gd_stack, 0);
     apr_thread_mutex_destroy(gd_lock);
     apr_thread_cond_destroy(gd_cond);
     apr_pool_destroy(gd_pool);
@@ -214,7 +214,7 @@ op_generic_t *gop_dummy(op_status_t state)
     tbx_type_malloc_clear(gop, op_generic_t, 1);
 
     log_printf(15, " state=%d\n", state.op_status);
-    tbx_flush_log();
+    tbx_log_flush();
 
     gop_init(gop);
     gop->base.pc = &_gop_dummy_pc;
@@ -566,7 +566,7 @@ op_generic_t *gop_waitany(op_generic_t *g)
 //_opque_print_stack(g->q->finished);
     } else {
         log_printf(15, "gop_waitany: BEFORE (type=op) While gid=%d state=%d\n", gop_id(g), g->base.state);
-        tbx_flush_log();
+        tbx_log_flush();
         if ((g->base.pc->fn->sync_exec != NULL) && (g->base.started_execution == 0)) {  //** See if we can directly exec
             unlock_gop(g);  //** Don't need this for a direct exec
             log_printf(15, "sync_exec -- waiting for gid=%d to complete\n", gop_id(g));
@@ -582,7 +582,7 @@ op_generic_t *gop_waitany(op_generic_t *g)
             }
         }
         log_printf(15, "gop_waitany: AFTER (type=op) While gid=%d state=%d\n", gop_id(g), g->base.state);
-        tbx_flush_log();
+        tbx_log_flush();
     }
     unlock_gop(g);
 

--- a/src/gop/hconnection.c
+++ b/src/gop/hconnection.c
@@ -139,14 +139,14 @@ int check_workload(host_connection_t *hc)
     while ((hc->curr_workload >= hc->hp->context->max_workload) && (hc->shutdown_request == 0)) {
         dt = apr_time_now();
         sec = dt / APR_USEC_PER_SEC;
-        log_printf(15, "check_workload: *workload loop* shutdown_request=%d stack_size=%d curr_workload=%d time=%d sec\n", hc->shutdown_request, tbx_stack_size(hc->pending_stack), hc->curr_workload, sec);
+        log_printf(15, "check_workload: *workload loop* shutdown_request=%d stack_size=%d curr_workload=%d time=%d sec\n", hc->shutdown_request, tbx_stack_count(hc->pending_stack), hc->curr_workload, sec);
         apr_thread_cond_wait(hc->send_cond, hc->lock);
         dt = apr_time_now() - dt;
         sec = dt / APR_USEC_PER_SEC;
-        log_printf(15, "check_workload: *workload loop* AFTER sleep shutdown_request=%d stack_size=%d curr_workload=%d slept=%d sec\n", hc->shutdown_request, tbx_stack_size(hc->pending_stack), hc->curr_workload, sec);
+        log_printf(15, "check_workload: *workload loop* AFTER sleep shutdown_request=%d stack_size=%d curr_workload=%d slept=%d sec\n", hc->shutdown_request, tbx_stack_count(hc->pending_stack), hc->curr_workload, sec);
     }
 
-    psize = tbx_stack_size(hc->pending_stack);
+    psize = tbx_stack_count(hc->pending_stack);
     unlock_hc(hc);
 
     return(psize);
@@ -160,8 +160,8 @@ int check_workload(host_connection_t *hc)
 void empty_work_que(host_connection_t *hc)
 {
     lock_hc(hc);
-    while (tbx_stack_size(hc->pending_stack) != 0) {
-        log_printf(15, "empty_work_que: shutdown_request=%d stack_size=%d curr_workload=%d\n", hc->shutdown_request, tbx_stack_size(hc->pending_stack), hc->curr_workload);
+    while (tbx_stack_count(hc->pending_stack) != 0) {
+        log_printf(15, "empty_work_que: shutdown_request=%d stack_size=%d curr_workload=%d\n", hc->shutdown_request, tbx_stack_count(hc->pending_stack), hc->curr_workload);
         apr_thread_cond_signal(hc->recv_cond);
         apr_thread_cond_wait(hc->send_cond, hc->lock);
     }
@@ -187,7 +187,7 @@ void empty_hp_que(host_portal_t *hp, op_status_t err_code)
 void recv_wait_for_work(host_connection_t *hc)
 {
     lock_hc(hc);
-    while ((hc->shutdown_request == 0) && (tbx_stack_size(hc->pending_stack) == 0)) {
+    while ((hc->shutdown_request == 0) && (tbx_stack_count(hc->pending_stack) == 0)) {
         hc_send_signal(hc);
         log_printf(5, "shutdown_request=%d\n", hc->shutdown_request);
         apr_thread_cond_wait(hc->recv_cond, hc->lock);
@@ -293,7 +293,7 @@ void *hc_send_thread(apr_thread_t *th, void *data)
 
             lock_hc(hc);  //** Check if this command is on top
             hc->curr_op = hsop;  //** Make sure the current op doesn't get lost if needed
-            if (tbx_stack_size(hc->pending_stack) == 0) tbx_atomic_set(hop->on_top, 1);
+            if (tbx_stack_count(hc->pending_stack) == 0) tbx_atomic_set(hop->on_top, 1);
             unlock_hc(hc);
 
             finished = (hop->send_command != NULL) ? hop->send_command(hsop, ns) : op_success_status;
@@ -303,7 +303,7 @@ void *hc_send_thread(apr_thread_t *th, void *data)
                 hc->last_used = apr_time_now();  //** Update  the time.  The recv thread does this also
                 hc->curr_workload += hop->workload;  //** Inc the current workload
                 if (tbx_atomic_get(hop->on_top) == 0) {
-                    if (tbx_stack_size(hc->pending_stack) == 0) {
+                    if (tbx_stack_count(hc->pending_stack) == 0) {
                         tbx_atomic_set(hop->on_top, 1);
                         hop->start_time = apr_time_now();  //** This is the real start/end time now
                         hop->end_time = hop->start_time + hop->timeout;
@@ -329,7 +329,7 @@ void *hc_send_thread(apr_thread_t *th, void *data)
 
         lock_hc(hc);
 
-        if (tbx_stack_size(hc->pending_stack) == 0) {
+        if (tbx_stack_count(hc->pending_stack) == 0) {
             dtime = apr_time_now() - hc->last_used; //** Exit if not busy
             if (dtime >= hpc->min_idle) {
                 hc->shutdown_request = 1;
@@ -347,7 +347,7 @@ void *hc_send_thread(apr_thread_t *th, void *data)
         }
 
         log_printf(15, "hc_send_thread: ns=%d shutdown=%d stack_size=%d curr_workload=%d time=" TT " last_used=" TT "\n", tbx_ns_getid(ns),
-                   hc->shutdown_request, tbx_stack_size(hc->pending_stack), hc->curr_workload, apr_time_now(), hc->last_used);
+                   hc->shutdown_request, tbx_stack_count(hc->pending_stack), hc->curr_workload, apr_time_now(), hc->last_used);
         unlock_hc(hc);
     }
 
@@ -357,7 +357,7 @@ void *hc_send_thread(apr_thread_t *th, void *data)
 
     log_printf(15, "hc_send_thread: Exiting! (ns=%d, host=%s:%d)\n", tbx_ns_getid(ns), hp->host, hp->port);
 
-    hc->shutdown_request = (tbx_stack_size(hc->pending_stack) == 0) ? 1 : 2;
+    hc->shutdown_request = (tbx_stack_count(hc->pending_stack) == 0) ? 1 : 2;
     apr_thread_cond_signal(hc->recv_cond);
     unlock_hc(hc);
 
@@ -541,7 +541,7 @@ void *hc_recv_thread(apr_thread_t *th, void *data)
         }
         hportal_unlock(hp);
     } else {
-        log_printf(15, "hc_recv_thread: ns=%d stack_size=%d\n", tbx_ns_getid(ns), tbx_stack_size(hc->pending_stack));
+        log_printf(15, "hc_recv_thread: ns=%d stack_size=%d\n", tbx_ns_getid(ns), tbx_stack_count(hc->pending_stack));
 
         if (hc->curr_op != NULL) {  //** This is from the sending thread
             log_printf(15, "hc_recv_thread: ns=%d Pushing sending thread task on stack gid=%d\n", tbx_ns_getid(ns), gop_id(hc->curr_op));
@@ -566,7 +566,7 @@ void *hc_recv_thread(apr_thread_t *th, void *data)
     hportal_lock(hp);
 
     //** Now remove myself from the hportal
-//  if (hp->n_conn != tbx_stack_size(hp->conn_list)) log_printf(0, "hc_recv_thread: ns=%d hp->n_conn=%d tbx_stack_size(hp->conn_list)=%d N_CONN ERROR!!!!!!\n", tbx_ns_getid(ns), hp->n_conn, tbx_stack_size(hp->conn_list));
+//  if (hp->n_conn != tbx_stack_count(hp->conn_list)) log_printf(0, "hc_recv_thread: ns=%d hp->n_conn=%d tbx_stack_count(hp->conn_list)=%d N_CONN ERROR!!!!!!\n", tbx_ns_getid(ns), hp->n_conn, tbx_stack_count(hp->conn_list));
 
     hp->oops_recv_end++;
     if (hp->n_conn < 0) hp->oops_neg++;

--- a/src/gop/hportal.c
+++ b/src/gop/hportal.c
@@ -194,7 +194,7 @@ void _reap_hportal(host_portal_t *hp, int quick)
 
 void destroy_hportal(host_portal_t *hp)
 {
-    log_printf(5, "host=%s conn_list=%d closed=%d\n", hp->host, tbx_stack_size(hp->conn_list),tbx_stack_size(hp->closed_que));
+    log_printf(5, "host=%s conn_list=%d closed=%d\n", hp->host, tbx_stack_count(hp->conn_list),tbx_stack_count(hp->closed_que));
     hportal_lock(hp);
     _reap_hportal(hp, 0);
     hportal_unlock(hp);
@@ -296,14 +296,14 @@ void shutdown_direct(host_portal_t *hp)
     host_portal_t *shp;
     host_connection_t *hc;
 
-    if (tbx_stack_size(hp->direct_list) == 0) return;
+    if (tbx_stack_count(hp->direct_list) == 0) return;
 
     tbx_stack_move_to_top(hp->direct_list);
     while ((shp = (host_portal_t *)tbx_stack_pop(hp->direct_list)) != NULL) {
         hportal_lock(shp);
         _reap_hportal(shp, 0);  //** Clean up any closed connections
 
-        if ((shp->n_conn == 0) && (tbx_stack_size(shp->que) == 0)) { //** if not used so remove it
+        if ((shp->n_conn == 0) && (tbx_stack_count(shp->que) == 0)) { //** if not used so remove it
             tbx_stack_delete_current(hp->direct_list, 0, 0);  //**Already closed
         } else {     //** Force it to close
             tbx_stack_free(shp->que, 1);  //** Empty the que so we don't respawn connections
@@ -349,14 +349,14 @@ void shutdown_hportal(portal_context_t *hpc)
         hp = (host_portal_t *)val;
         hportal_lock(hp);
 
-        log_printf(5, "before wait n_conn=%d tbx_stack_size(conn_list)=%d host=%s\n", hp->n_conn, tbx_stack_size(hp->conn_list), hp->skey);
-        while (tbx_stack_size(hp->conn_list) != hp->n_conn) {
+        log_printf(5, "before wait n_conn=%d tbx_stack_count(conn_list)=%d host=%s\n", hp->n_conn, tbx_stack_count(hp->conn_list), hp->skey);
+        while (tbx_stack_count(hp->conn_list) != hp->n_conn) {
             hportal_unlock(hp);
-            log_printf(5, "waiting for connections to finish starting.  host=%s closing_conn=%d n_conn=%d tbx_stack_size(conn_list)=%d\n", hp->skey, hp->closing_conn, hp->n_conn, tbx_stack_size(hp->conn_list));
+            log_printf(5, "waiting for connections to finish starting.  host=%s closing_conn=%d n_conn=%d tbx_stack_count(conn_list)=%d\n", hp->skey, hp->closing_conn, hp->n_conn, tbx_stack_count(hp->conn_list));
             usleep(10000);
             hportal_lock(hp);
         }
-        log_printf(5, "after wait n_conn=%d tbx_stack_size(conn_list)=%d\n", hp->n_conn, tbx_stack_size(hp->conn_list));
+        log_printf(5, "after wait n_conn=%d tbx_stack_count(conn_list)=%d\n", hp->n_conn, tbx_stack_count(hp->conn_list));
 
         tbx_stack_move_to_top(hp->conn_list);
         while ((hc = (host_connection_t *)tbx_stack_get_current_data(hp->conn_list)) != NULL) {
@@ -392,7 +392,7 @@ void shutdown_hportal(portal_context_t *hpc)
 
         log_printf(5, "closing_conn=%d n_conn=%d\n", hp->closing_conn, hp->n_conn);
         while ((hp->closing_conn > 0) || (hp->n_conn > 0)) {
-            log_printf(5, "waiting for connections to close.  host=%s closing_conn=%d n_conn=%d tbx_stack_size(conn_list)=%d\n", hp->skey, hp->closing_conn, hp->n_conn, tbx_stack_size(hp->conn_list));
+            log_printf(5, "waiting for connections to close.  host=%s closing_conn=%d n_conn=%d tbx_stack_count(conn_list)=%d\n", hp->skey, hp->closing_conn, hp->n_conn, tbx_stack_count(hp->conn_list));
             hportal_unlock(hp);
             usleep(10000);
             hportal_lock(hp);
@@ -433,7 +433,7 @@ void compact_hportal_direct(host_portal_t *hp)
 {
     host_portal_t *shp;
 
-    if (tbx_stack_size(hp->direct_list) == 0) return;
+    if (tbx_stack_count(hp->direct_list) == 0) return;
 
     tbx_stack_move_to_top(hp->direct_list);
     while ((shp = (host_portal_t *)tbx_stack_get_current_data(hp->direct_list)) != NULL) {
@@ -441,7 +441,7 @@ void compact_hportal_direct(host_portal_t *hp)
         hportal_lock(shp);
         _reap_hportal(shp, 1);  //** Clean up any closed connections
 
-        if ((shp->n_conn == 0) && (shp->closing_conn == 0) && (tbx_stack_size(shp->que) == 0) && (tbx_stack_size(shp->closed_que) == 0)) { //** if not used so remove it
+        if ((shp->n_conn == 0) && (shp->closing_conn == 0) && (tbx_stack_count(shp->que) == 0) && (tbx_stack_count(shp->closed_que) == 0)) { //** if not used so remove it
             tbx_stack_delete_current(hp->direct_list, 0, 0);
             hportal_unlock(shp);
             destroy_hportal(shp);
@@ -476,12 +476,12 @@ void compact_hportals(portal_context_t *hpc)
 
         compact_hportal_direct(hp);
 
-        if ((hp->n_conn == 0) && (hp->closing_conn == 0) && (tbx_stack_size(hp->que) == 0) &&
-                (tbx_stack_size(hp->direct_list) == 0) && (tbx_stack_size(hp->closed_que) == 0)) { //** if not used so remove it
-            if (tbx_stack_size(hp->conn_list) != 0) {
-                log_printf(0, "ERROR! DANGER WILL ROBINSON! tbx_stack_size(hp->conn_list)=%d hp=%s\n", tbx_stack_size(hp->conn_list), hp->skey);
+        if ((hp->n_conn == 0) && (hp->closing_conn == 0) && (tbx_stack_count(hp->que) == 0) &&
+                (tbx_stack_count(hp->direct_list) == 0) && (tbx_stack_count(hp->closed_que) == 0)) { //** if not used so remove it
+            if (tbx_stack_count(hp->conn_list) != 0) {
+                log_printf(0, "ERROR! DANGER WILL ROBINSON! tbx_stack_count(hp->conn_list)=%d hp=%s\n", tbx_stack_count(hp->conn_list), hp->skey);
                 tbx_log_flush();
-                assert(tbx_stack_size(hp->conn_list) == 0);
+                assert(tbx_stack_count(hp->conn_list) == 0);
             } else {
                 hportal_unlock(hp);
                 apr_hash_set(hpc->table, hp->skey, APR_HASH_KEY_STRING, NULL);  //** This removes the key
@@ -562,7 +562,7 @@ void _add_hportal_op(host_portal_t *hp, op_generic_t *hsop, int addtotop, int re
 
 op_generic_t *_get_hportal_op(host_portal_t *hp)
 {
-    log_printf(16, "_get_hportal_op: stack_size=%d\n", tbx_stack_size(hp->que));
+    log_printf(16, "_get_hportal_op: stack_size=%d\n", tbx_stack_count(hp->que));
 
     op_generic_t *hsop;
 
@@ -630,7 +630,7 @@ host_connection_t *find_hc_to_close(portal_context_t *hpc)
         tbx_stack_move_to_top(hp->direct_list);
         while ((shp = (host_portal_t *)tbx_stack_get_current_data(hp->direct_list)) != NULL)  {
             hportal_lock(shp);
-            if (tbx_stack_size(shp->conn_list) > 0) {
+            if (tbx_stack_count(shp->conn_list) > 0) {
                 tbx_stack_move_to_top(shp->conn_list);
                 hc = (host_connection_t *)tbx_stack_get_current_data(shp->conn_list);
                 hold_lock = 0;
@@ -727,7 +727,7 @@ void check_hportal_connections(host_portal_t *hp)
     curr_workload = hp->workload + hp->executing_workload;
 
     //** Now figure out how many new connections are needed, if any
-    if (tbx_stack_size(hp->que) == 0) {
+    if (tbx_stack_count(hp->que) == 0) {
         n_newconn = 0;
     } else if (hp->n_conn < hp->min_conn) {
         n_newconn = hp->min_conn - hp->n_conn;
@@ -772,12 +772,12 @@ void check_hportal_connections(host_portal_t *hp)
 
     //** Do a check for invalid or down host
     if (hp->invalid_host == 1) {
-        if ((hp->n_conn == 0) && (tbx_stack_size(hp->que) > 0)) n_newconn = 1;   //** If no connections create one to sink the command
+        if ((hp->n_conn == 0) && (tbx_stack_count(hp->que) > 0)) n_newconn = 1;   //** If no connections create one to sink the command
     }
 
     j = (hp->pause_until > apr_time_now()) ? 1 : 0;
     log_printf(6, "check_hportal_connections: host=%s n_conn=%d sleeping=%d workload=" I64T " curr_wl=" I64T " exec_wl=" I64T " start_new_conn=%d new_conn=%d stable=%d stack_size=%d pause_until=" TT " now=" TT " pause_until_blocked=%d\n",
-               hp->skey, hp->n_conn, hp->sleeping_conn, hp->workload, curr_workload, hp->executing_workload, i, n_newconn, hp->stable_conn, tbx_stack_size(hp->que), hp->pause_until, apr_time_now(), j);
+               hp->skey, hp->n_conn, hp->sleeping_conn, hp->workload, curr_workload, hp->executing_workload, i, n_newconn, hp->stable_conn, tbx_stack_count(hp->que), hp->pause_until, apr_time_now(), j);
 
     //** Update the total # of connections after the operation
     //** n_conn is used instead of conn_list to prevent false positives on a dead depot
@@ -837,14 +837,14 @@ int submit_hp_direct_op(portal_context_t *hpc, op_generic_t *op)
     tbx_stack_move_to_top(hp->direct_list);
     while ((shp = (host_portal_t *)tbx_stack_get_current_data(hp->direct_list)) != NULL)  {
         if (hportal_trylock(shp) == 0) {
-            log_printf(15, "submit_hp_direct_op: opid=%d shp->wl=" I64T " stack_size=%d\n", op->base.id, shp->workload, tbx_stack_size(shp->que));
+            log_printf(15, "submit_hp_direct_op: opid=%d shp->wl=" I64T " stack_size=%d\n", op->base.id, shp->workload, tbx_stack_count(shp->que));
 
-            if (tbx_stack_size(shp->que) == 0) {
-                if (tbx_stack_size(shp->conn_list) > 0) {
+            if (tbx_stack_count(shp->que) == 0) {
+                if (tbx_stack_count(shp->conn_list) > 0) {
                     tbx_stack_move_to_top(shp->conn_list);
                     hc = (host_connection_t *)tbx_stack_get_current_data(shp->conn_list);
                     if (trylock_hc(hc) == 0) {
-                        if ((tbx_stack_size(hc->pending_stack) == 0) && (hc->curr_workload == 0)) {
+                        if ((tbx_stack_count(hc->pending_stack) == 0) && (hc->curr_workload == 0)) {
                             log_printf(15, "submit_hp_direct_op(A): before submit ns=%d opid=%d wl=%d\n",tbx_ns_getid(hc->ns), op->base.id, hc->curr_workload);
                             unlock_hc(hc);
                             hportal_unlock(shp);

--- a/src/gop/mq_msg.c
+++ b/src/gop/mq_msg.c
@@ -190,7 +190,7 @@ void mq_msg_append_msg(mq_msg_t *msg, mq_msg_t *extra, int mode)
     char *data;
 
     tbx_stack_move_to_top(msg);
-    for (curr = tbx_stack_top_get(msg); 
+    for (curr = tbx_stack_get_top(msg); 
             curr != NULL;
             curr = tbx_stack_ele_get_down(curr)) {
         f = (mq_frame_t *)tbx_stack_ele_get_data(curr);
@@ -215,7 +215,7 @@ mq_msg_hash_t mq_msg_hash(mq_msg_t *msg)
 
     n = 0;
     h.full_hash = h.even_hash = 0;
-    for (curr = tbx_stack_top_get(msg); 
+    for (curr = tbx_stack_get_top(msg); 
             curr != NULL;
             curr = tbx_stack_ele_get_down(curr)) {
         f = (mq_frame_t *)tbx_stack_ele_get_data(curr);

--- a/src/gop/mq_msg.c
+++ b/src/gop/mq_msg.c
@@ -74,31 +74,31 @@ mq_msg_t *mq_msg_new()
 mq_frame_t *mq_msg_first(mq_msg_t *msg)
 {
     tbx_stack_move_to_top(msg);
-    return((mq_frame_t *)tbx_get_ele_data(msg));
+    return((mq_frame_t *)tbx_stack_get_current_data(msg));
 }
 mq_frame_t *mq_msg_last(mq_msg_t *msg)
 {
     tbx_stack_move_to_bottom(msg);
-    return((mq_frame_t *)tbx_get_ele_data(msg));
+    return((mq_frame_t *)tbx_stack_get_current_data(msg));
 }
 mq_frame_t *mq_msg_next(mq_msg_t *msg)
 {
     tbx_stack_move_down(msg);
-    return((mq_frame_t *)tbx_get_ele_data(msg));
+    return((mq_frame_t *)tbx_stack_get_current_data(msg));
 }
 mq_frame_t *mq_msg_prev(mq_msg_t *msg)
 {
     tbx_stack_move_up(msg);
-    return((mq_frame_t *)tbx_get_ele_data(msg));
+    return((mq_frame_t *)tbx_stack_get_current_data(msg));
 }
 mq_frame_t *mq_msg_current(mq_msg_t *msg)
 {
-    return((mq_frame_t *)tbx_get_ele_data(msg));
+    return((mq_frame_t *)tbx_stack_get_current_data(msg));
 }
 mq_frame_t *mq_msg_pluck(mq_msg_t *msg, int move_up)
 {
-    mq_frame_t *f = tbx_get_ele_data(msg);
-    tbx_delete_current(msg, move_up, 0);
+    mq_frame_t *f = tbx_stack_get_current_data(msg);
+    tbx_stack_delete_current(msg, move_up, 0);
     return(f);
 }
 void mq_msg_tbx_stack_insert_above(mq_msg_t *msg, mq_frame_t *f)
@@ -170,7 +170,7 @@ void mq_msg_destroy(mq_msg_t *msg)
         mq_frame_destroy(f);
     }
 
-    tbx_free_stack(msg, 0);
+    tbx_stack_free(msg, 0);
 }
 
 void mq_msg_push_mem(mq_msg_t *msg, void *data, int len, int auto_free)
@@ -192,8 +192,8 @@ void mq_msg_append_msg(mq_msg_t *msg, mq_msg_t *extra, int mode)
     tbx_stack_move_to_top(msg);
     for (curr = tbx_stack_top_get(msg); 
             curr != NULL;
-            curr = tbx_stack_ele_down_get(curr)) {
-        f = (mq_frame_t *)tbx_stack_ele_data_get(curr);
+            curr = tbx_stack_ele_get_down(curr)) {
+        f = (mq_frame_t *)tbx_stack_ele_get_data(curr);
         if (mode == MQF_MSG_AUTO_FREE) {
             tbx_type_malloc(data, char, f->len);
             memcpy(data, f->data, f->len);
@@ -217,8 +217,8 @@ mq_msg_hash_t mq_msg_hash(mq_msg_t *msg)
     h.full_hash = h.even_hash = 0;
     for (curr = tbx_stack_top_get(msg); 
             curr != NULL;
-            curr = tbx_stack_ele_down_get(curr)) {
-        f = (mq_frame_t *)tbx_stack_ele_data_get(curr);
+            curr = tbx_stack_ele_get_down(curr)) {
+        f = (mq_frame_t *)tbx_stack_ele_get_data(curr);
         mq_get_frame(f, (void **)&data, &size);
         for (p = data; size > 0; p++, size--) {
             h.full_hash = h.full_hash * 33 + *p;
@@ -242,7 +242,7 @@ int mq_msg_total_size(mq_msg_t *msg)
 
     n = 0;
     tbx_stack_move_to_top(msg);
-    while ((f = tbx_get_ele_data(msg)) != NULL) {
+    while ((f = tbx_stack_get_current_data(msg)) != NULL) {
         n += f->len;
         tbx_stack_move_down(msg);
     }

--- a/src/gop/mq_ongoing.c
+++ b/src/gop/mq_ongoing.c
@@ -95,7 +95,7 @@ void *ongoing_heartbeat_thread(apr_thread_t *th, void *data)
                                         oh->id,
                                         ((apr_time_t) apr_time_sec(apr_time_now())),
                                         oh->heartbeat);
-                    tbx_flush_log();
+                    tbx_log_flush();
                     //** Form the message
                     msg = mq_make_exec_core_msg(table->remote_host, 1);
                     mq_msg_append_mem(msg, ONGOING_KEY, ONGOING_SIZE, MQF_MSG_KEEP_DATA);
@@ -439,7 +439,7 @@ void mq_ongoing_cb(void *arg, mq_task_t *task)
 
     log_printf(1, "Processing incoming request. EXEC START now=" TT "\n",
                     ((apr_time_t) apr_time_sec(apr_time_now())));
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Parse the command.
     msg = task->msg;

--- a/src/gop/mq_portal.c
+++ b/src/gop/mq_portal.c
@@ -299,12 +299,12 @@ int mq_submit(mq_portal_t *p, mq_task_t *task)
     apr_thread_mutex_lock(p->lock);
 
 //** Do a quick check for connections that need to be reaped
-    if (tbx_stack_size(p->closed_conn) > 0) _mq_reap_closed(p);
+    if (tbx_stack_count(p->closed_conn) > 0) _mq_reap_closed(p);
 
 //** Add the task and get the backlog
     tbx_stack_move_to_bottom(p->tasks);
     tbx_stack_insert_below(p->tasks, task);
-    backlog = tbx_stack_size(p->tasks);
+    backlog = tbx_stack_count(p->tasks);
     log_printf(2, "portal=%s backlog=%d active_conn=%d max_conn=%d total_conn=%d\n", p->host, backlog, p->active_conn, p->max_conn, p->total_conn);
     tbx_log_flush();
 
@@ -670,7 +670,7 @@ void mqc_trackaddress(mq_conn_t *c, mq_msg_t *msg)
 
         //** What's left is the address until an empty frame
         size = mq_msg_total_size(msg);
-        log_printf(5, " msg_total_size=%d frames=%d\n", size, tbx_stack_size(msg));
+        log_printf(5, " msg_total_size=%d frames=%d\n", size, tbx_stack_count(msg));
         tbx_type_malloc_clear(address, char, size+1);
         n = 0;
         for (f=mq_msg_first(msg); f != NULL; f=mq_msg_next(msg)) {
@@ -1657,7 +1657,7 @@ void mq_portal_destroy(mq_portal_t *p)
     }
     apr_thread_mutex_unlock(p->lock);
 
-    log_printf(2, "host=%s closed_size=%d total_conn=%d\n", p->host, tbx_stack_size(p->closed_conn), p->total_conn);
+    log_printf(2, "host=%s closed_size=%d total_conn=%d\n", p->host, tbx_stack_count(p->closed_conn), p->total_conn);
     tbx_log_flush();
 
     //** Clean up 

--- a/src/gop/mq_roundrobin.c
+++ b/src/gop/mq_roundrobin.c
@@ -6,13 +6,13 @@
 mq_worker_t *mq_worker_table_first(mq_worker_table_t *table)
 {
     tbx_stack_move_to_top(table);
-    return (mq_worker_t *)tbx_get_ele_data(table);
+    return (mq_worker_t *)tbx_stack_get_current_data(table);
 }
 
 mq_worker_t *mq_worker_table_next(mq_worker_table_t *table)
 {
     tbx_stack_move_down(table);
-    return (mq_worker_t *)tbx_get_ele_data(table);
+    return (mq_worker_t *)tbx_stack_get_current_data(table);
 }
 
 mq_worker_t *mq_worker_create(char *address, int free_slots)
@@ -42,7 +42,7 @@ void mq_worker_table_destroy(mq_worker_table_t *table)
         free(worker->address);
         free(worker);
     }
-    tbx_free_stack(table, 0);
+    tbx_stack_free(table, 0);
     log_printf(5, "Successfully destroyed worker table\n");
 }
 
@@ -59,7 +59,7 @@ mq_worker_t *mq_get_worker(mq_worker_table_t *table, char *address)
         for(worker = mq_worker_table_first(table); worker != NULL; worker = mq_worker_table_next(table)) {
             if(mq_data_compare(worker->address, strlen(worker->address), address, strlen(address)) == 0) {
                 log_printf(10, "Found worker!\n");
-                tbx_delete_current(table, 0, 0);
+                tbx_stack_delete_current(table, 0, 0);
                 return worker;
             }
         }
@@ -76,7 +76,7 @@ mq_worker_t *mq_get_available_worker(mq_worker_table_t *table)
     mq_worker_t *worker;
     for(worker = mq_worker_table_first(table); worker != NULL; worker = mq_worker_table_next(table)) {
         if(worker->free_slots > 0) {
-            tbx_delete_current(table, 0, 0);
+            tbx_stack_delete_current(table, 0, 0);
             return worker;
         }
     }
@@ -112,7 +112,7 @@ void mq_deregister_worker(mq_worker_table_t *table, char *address)
     for(worker = mq_worker_table_first(table); worker != NULL; worker = mq_worker_table_next(table)) {
         if(mq_data_compare(worker->address, strlen(worker->address), address, strlen(address)) == 0) {
             log_printf(5, "Removing worker with address %s, free slots %d\n", worker->address, worker->free_slots);
-            tbx_delete_current(table, 0, 0);
+            tbx_stack_delete_current(table, 0, 0);
             free(worker->address);
             free(worker);
             return;
@@ -231,10 +231,10 @@ int processing_queue_length(mq_processing_queue *queue)
     mq_msg_t *m;
     int i = 0;
     tbx_stack_move_to_top(queue);
-    m = (mq_msg_t *)tbx_get_ele_data(queue);
+    m = (mq_msg_t *)tbx_stack_get_current_data(queue);
     while(m != NULL) {
         tbx_stack_move_down(queue);
-        m = (mq_msg_t *)tbx_get_ele_data(queue);
+        m = (mq_msg_t *)tbx_stack_get_current_data(queue);
         i++;
     }
     return i;

--- a/src/gop/mq_stream.c
+++ b/src/gop/mq_stream.c
@@ -460,7 +460,7 @@ int mqs_write_send(mq_stream_t *mqs, mq_msg_t *address, mq_frame_t *fid)
         mqs->want_more = MQS_ABORT;
     }
 
-//tbx_flush_log();
+//tbx_log_flush();
 //sleep(5);
     return(err);
 }

--- a/src/gop/mq_stream.c
+++ b/src/gop/mq_stream.c
@@ -421,7 +421,7 @@ int mqs_write_send(mq_stream_t *mqs, mq_msg_t *address, mq_frame_t *fid)
 
     if (mqs->data == NULL) return(-1);
 
-    log_printf(1, "msid=%d address frame count=%d state_index=%c\n", mqs->msid, tbx_stack_size(address), mqs->data[MQS_STATE_INDEX]);
+    log_printf(1, "msid=%d address frame count=%d state_index=%c\n", mqs->msid, tbx_stack_count(address), mqs->data[MQS_STATE_INDEX]);
     response = mq_make_response_core_msg(address, fid);
     mq_msg_append_mem(response, mqs->data, MQS_HEADER + tbx_pack_used(mqs->pack), MQF_MSG_AUTO_FREE);
     mq_msg_append_mem(response, NULL, 0, MQF_MSG_KEEP_DATA);  //** Empty frame

--- a/src/gop/mq_test.c
+++ b/src/gop/mq_test.c
@@ -766,7 +766,7 @@ int server_handle_deferred(mq_socket_t *sock)
     int err;
     char v;
 
-    log_printf(5, "deferred responses to handle %d (server_portal=%p)\n", tbx_stack_size(deferred_ready), server_portal);
+    log_printf(5, "deferred responses to handle %d (server_portal=%p)\n", tbx_stack_count(deferred_ready), server_portal);
 
     err = 0;
     while ((defer = tbx_stack_pop(deferred_ready)) != NULL) {
@@ -1156,7 +1156,7 @@ void *server_deferred_thread(apr_thread_t *th, void *arg)
         if (dt > max_wait) dt = max_wait;
         apr_thread_cond_timedwait(cond, lock, dt);
 
-        log_printf(5, "checking deferred_pending stack_size=%d\n", tbx_stack_size(deferred_pending));
+        log_printf(5, "checking deferred_pending stack_size=%d\n", tbx_stack_count(deferred_pending));
         //** Move anything expired to the ready queue
         //** Keeping track of the next wakeup call
         dt = apr_time_make(100, 0);
@@ -1176,7 +1176,7 @@ void *server_deferred_thread(apr_thread_t *th, void *arg)
             }
         }
 
-        log_printf(5, "deferred_ready=%d deferred_pending=%d n= " LU " server_portal=%p\n", tbx_stack_size(deferred_ready), tbx_stack_size(deferred_pending), n, server_portal);
+        log_printf(5, "deferred_ready=%d deferred_pending=%d n= " LU " server_portal=%p\n", tbx_stack_count(deferred_ready), tbx_stack_count(deferred_pending), n, server_portal);
 
         if (n > 0) { //** Got tasks to send
             if (server_portal == NULL) {

--- a/src/gop/mq_test.c
+++ b/src/gop/mq_test.c
@@ -570,7 +570,7 @@ mq_context_t *client_make_context()
     tbx_inip_file_t *ifd;
     mq_context_t *mqc;
 
-    ifd = tbx_inip_read_string(text_params);
+    ifd = tbx_inip_string_read(text_params);
     mqc = mq_create_context(ifd, "mq_context");
     assert(mqc != NULL);
     tbx_inip_destroy(ifd);
@@ -1068,7 +1068,7 @@ mq_context_t *server_make_context()
     tbx_inip_file_t *ifd;
     mq_context_t *mqc;
 
-    ifd = tbx_inip_read_string(text_params);
+    ifd = tbx_inip_string_read(text_params);
     mqc = mq_create_context(ifd, "mq_context");
     assert(mqc != NULL);
     tbx_inip_destroy(ifd);

--- a/src/gop/mq_zmq.c
+++ b/src/gop/mq_zmq.c
@@ -78,7 +78,7 @@ int zero_native_connect(mq_socket_t *socket, const char *format, ...)
     //** Set the ID
     if (socket->type != MQ_PAIR) {
         snprintf(buf, 255, format, args);
-        snprintf(id, 255, "%s:" I64T , buf, tbx_random_int64(1, 1000000));
+        snprintf(id, 255, "%s:" I64T , buf, tbx_random_get_int64(1, 1000000));
         zsocket_set_identity(socket->arg, id);
         log_printf(4, "Unique hostname created = %s\n", id);
     }
@@ -130,10 +130,10 @@ int zero_native_send(mq_socket_t *socket, mq_msg_t *msg, int flags)
     f = mq_msg_first(msg);
     if (f->len > 1) {
         log_printf(5, "dest=!%.*s! nframes=%d\n", f->len, (char *)(f->data), tbx_stack_size(msg));
-        tbx_flush_log();
+        tbx_log_flush();
     } else {
         log_printf(5, "dest=(single byte) nframes=%d\n", tbx_stack_size(msg));
-        tbx_flush_log();
+        tbx_log_flush();
     }
 
     while ((fn = mq_msg_next(msg)) != NULL) {
@@ -145,10 +145,10 @@ int zero_native_send(mq_socket_t *socket, mq_msg_t *msg, int flags)
             }
             loop++;
             log_printf(5, "sending frame=%d len=%d bytes=%d errno=%d loop=%d\n", count, f->len, bytes, errno, loop);
-            tbx_flush_log();
+            tbx_log_flush();
             if (f->len>0) {
                 log_printf(5, "byte=%uc\n", (unsigned char)f->data[0]);
-                tbx_flush_log();
+                tbx_log_flush();
             }
         } while ((bytes == -1) && (loop < 10));
         n += bytes;
@@ -401,10 +401,10 @@ void zero_socket_context_destroy(mq_socket_context_t *ctx)
     //** zctx_destroy() close them
 //  sleep(1);
     log_printf(5, "after sleep\n");
-    tbx_flush_log();
+    tbx_log_flush();
     zctx_destroy((zctx_t **)&(ctx->arg));
     log_printf(5, "after zctx_destroy\n");
-    tbx_flush_log();
+    tbx_log_flush();
     free(ctx);
 }
 

--- a/src/gop/mq_zmq.c
+++ b/src/gop/mq_zmq.c
@@ -129,10 +129,10 @@ int zero_native_send(mq_socket_t *socket, mq_msg_t *msg, int flags)
     n = 0;
     f = mq_msg_first(msg);
     if (f->len > 1) {
-        log_printf(5, "dest=!%.*s! nframes=%d\n", f->len, (char *)(f->data), tbx_stack_size(msg));
+        log_printf(5, "dest=!%.*s! nframes=%d\n", f->len, (char *)(f->data), tbx_stack_count(msg));
         tbx_log_flush();
     } else {
-        log_printf(5, "dest=(single byte) nframes=%d\n", tbx_stack_size(msg));
+        log_printf(5, "dest=(single byte) nframes=%d\n", tbx_stack_count(msg));
         tbx_log_flush();
     }
 

--- a/src/gop/mqs_test.c
+++ b/src/gop/mqs_test.c
@@ -201,7 +201,7 @@ mq_context_t *client_make_context()
     mq_context_t *mqc;
 
     snprintf(buffer, sizeof(buffer), text_params, 100*nparallel);
-    ifd = tbx_inip_string_read(buffer);
+    ifd = tbx_inip_read_string(buffer);
     mqc = mq_create_context(ifd, "mq_context");
     assert(mqc != NULL);
     tbx_inip_destroy(ifd);
@@ -247,7 +247,7 @@ op_generic_t *test_gop(mq_context_t *mqc, int flusher, int client_delay, int del
     gop_set_myid(gop, myid);
 
     log_printf(0, "CREATE: gid=%d myid=%d test_gop(f=%d, cd=%d, sd=%d, mp=%d, sb=%d, to=%d) = %d\n", gop_id(gop), myid, op->launch_flusher, op->client_delay, op->delay, op->max_packet, op->send_bytes, op->timeout, op->shouldbe);
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(gop);
 }
@@ -264,25 +264,25 @@ op_generic_t *new_bulk_task(mq_context_t *mqc, int myid)
     to_min = 10;
     to_max = 20;
 
-    transfer_bytes = tbx_random_int64(send_min, send_max);
-    packet_bytes = tbx_random_int64(packet_min, packet_max);
-    to = tbx_random_int64(to_min, to_max);
-    delay = tbx_random_int64(1, 10);
+    transfer_bytes = tbx_random_get_int64(send_min, send_max);
+    packet_bytes = tbx_random_get_int64(packet_min, packet_max);
+    to = tbx_random_get_int64(to_min, to_max);
+    delay = tbx_random_get_int64(1, 10);
     if (delay == 1) {
-        delay = tbx_random_int64(to_min, to_max);
+        delay = tbx_random_get_int64(to_min, to_max);
         if (delay == to) delay += 2;
     } else {
         delay = 0;
     }
-    flusher = tbx_random_int64(1, 3);
+    flusher = tbx_random_get_int64(1, 3);
 //flusher = 1;
     if (flusher != 1) {
         flusher = 0;
     }
 
-    client_delay = tbx_random_int64(1, 10);
+    client_delay = tbx_random_get_int64(1, 10);
     if (client_delay == 1) {
-        client_delay = tbx_random_int64(to_min, to_max);
+        client_delay = tbx_random_get_int64(to_min, to_max);
         if (client_delay == to) client_delay -= 2;
     } else {
         client_delay = 0;
@@ -314,7 +314,7 @@ int client_consume_result(op_generic_t *gop)
         n = 0;
         log_printf(0, "SUCCESS with stream test! gid=%d myid=%d test_gop(f=%d, cd=%d sd=%d, mp=%d, sb=%d, to=%d) = %d got=%d\n", gop_id(gop), gop_get_myid(gop), op->launch_flusher, op->client_delay, op->delay, op->max_packet, op->send_bytes, op->timeout, op->shouldbe, status.op_status);
     }
-    tbx_flush_log();
+    tbx_log_flush();
 
     gop_free(gop, OP_DESTROY);
     free(op);
@@ -408,7 +408,7 @@ skip:
     if (q != NULL) opque_free(q, OP_DESTROY);
 
     log_printf(0, "END\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(NULL);
 }
@@ -457,9 +457,9 @@ void cb_write_stream(void *arg, mq_task_t *task)
     nleft = op->send_bytes;
     nsent = 0;
     do {
-        nbytes = tbx_random_int64(1, test_size);
+        nbytes = tbx_random_get_int64(1, test_size);
         if (nbytes > nleft) nbytes = nleft;
-        offset = tbx_random_int64(0, test_size-nbytes);
+        offset = tbx_random_get_int64(0, test_size-nbytes);
 
         log_printf(0, "nsent=%d  offset=%d nbytes=%d\n", nsent, offset, nbytes);
         err = mq_stream_write(mqs, &offset, sizeof(int));
@@ -490,7 +490,7 @@ fail:
     mq_stream_destroy(mqs);
 
     log_printf(0, "END gid=%d\n", err);
-    tbx_flush_log();
+    tbx_log_flush();
 
     apr_thread_mutex_lock(lock);
     in_process--;
@@ -519,7 +519,7 @@ mq_context_t *server_make_context()
     mq_context_t *mqc;
 
     snprintf(buffer, sizeof(buffer), text_params, 100*nparallel);
-    ifd = tbx_inip_string_read(buffer);
+    ifd = tbx_inip_read_string(buffer);
     mqc = mq_create_context(ifd, "mq_context");
     assert(mqc != NULL);
     tbx_inip_destroy(ifd);
@@ -572,7 +572,7 @@ void *server_test_thread(apr_thread_t *th, void *arg)
     mq_destroy_context(mqc);
 
     log_printf(0, "END\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(NULL);
 }
@@ -677,7 +677,7 @@ int main(int argc, char **argv)
 
     //** Make the test_data to pluck info from
     tbx_type_malloc_clear(test_data, char, test_size);
-    if (do_random == 1) tbx_random_bytes_get(test_data, test_size);
+    if (do_random == 1) tbx_random_get_bytes(test_data, test_size);
 
     //** Make the locking structures for client/server communication
     apr_pool_create(&mpool, NULL);

--- a/src/gop/mqs_test.c
+++ b/src/gop/mqs_test.c
@@ -201,7 +201,7 @@ mq_context_t *client_make_context()
     mq_context_t *mqc;
 
     snprintf(buffer, sizeof(buffer), text_params, 100*nparallel);
-    ifd = tbx_inip_read_string(buffer);
+    ifd = tbx_inip_string_read(buffer);
     mqc = mq_create_context(ifd, "mq_context");
     assert(mqc != NULL);
     tbx_inip_destroy(ifd);
@@ -519,7 +519,7 @@ mq_context_t *server_make_context()
     mq_context_t *mqc;
 
     snprintf(buffer, sizeof(buffer), text_params, 100*nparallel);
-    ifd = tbx_inip_read_string(buffer);
+    ifd = tbx_inip_string_read(buffer);
     mqc = mq_create_context(ifd, "mq_context");
     assert(mqc != NULL);
     tbx_inip_destroy(ifd);

--- a/src/gop/rr_mq_client.c
+++ b/src/gop/rr_mq_client.c
@@ -44,7 +44,7 @@ op_status_t read_stream(void *arg, int tid)
 
     int n_read, n_left, offset, n_bytes;
 
-    tbx_flush_log();
+    tbx_log_flush();
     log_printf(10, "CLIENT: Message frames BEFORE destroying:\n");
     display_msg_frames(msg);
 
@@ -278,7 +278,7 @@ mq_context_t *client_make_context()
 
     char buffer[1024];
     snprintf(buffer, sizeof(buffer), text_parameters, nparallel);
-    ifd = tbx_inip_string_read(buffer);
+    ifd = tbx_inip_read_string(buffer);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);
@@ -392,7 +392,7 @@ void client_test()
 {
     mq_context_t *mqc;
 
-    tbx_flush_log();
+    tbx_log_flush();
     log_printf(1, "CLIENT: Starting...\n");
 
     log_printf(15, "CLIENT: Creating context...\n");

--- a/src/gop/rr_mq_client.c
+++ b/src/gop/rr_mq_client.c
@@ -278,7 +278,7 @@ mq_context_t *client_make_context()
 
     char buffer[1024];
     snprintf(buffer, sizeof(buffer), text_parameters, nparallel);
-    ifd = tbx_inip_read_string(buffer);
+    ifd = tbx_inip_string_read(buffer);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);

--- a/src/gop/rr_mq_server.c
+++ b/src/gop/rr_mq_server.c
@@ -337,7 +337,7 @@ mq_context_t *server_make_context()
                             "socket_type=1002\n"; // Set socket type to MQF_ROUND_ROBIN
 
     tbx_log_flush();
-    ifd = tbx_inip_read_string(text_parameters);
+    ifd = tbx_inip_string_read(text_parameters);
 
     //log_printf(15, "SERVER: Creating context...\n");
     mqc = mq_create_context(ifd, "mq_context");

--- a/src/gop/rr_mq_server.c
+++ b/src/gop/rr_mq_server.c
@@ -336,8 +336,8 @@ mq_context_t *server_make_context()
                             "min_ops_per_sec=100\n"
                             "socket_type=1002\n"; // Set socket type to MQF_ROUND_ROBIN
 
-    tbx_flush_log();
-    ifd = tbx_inip_string_read(text_parameters);
+    tbx_log_flush();
+    ifd = tbx_inip_read_string(text_parameters);
 
     //log_printf(15, "SERVER: Creating context...\n");
     mqc = mq_create_context(ifd, "mq_context");

--- a/src/gop/rr_mq_test.c
+++ b/src/gop/rr_mq_test.c
@@ -208,8 +208,8 @@ mq_context_t *server_make_context()
                             "min_ops_per_sec=100\n\t"
                             "socket_type=1002\n"; // Set socket type to MQF_ROUND_ROBIN
 
-    tbx_flush_log();
-    ifd = tbx_inip_string_read(text_parameters);
+    tbx_log_flush();
+    ifd = tbx_inip_read_string(text_parameters);
 
     //log_printf(15, "SERVER: Creating context...\n");
     mqc = mq_create_context(ifd, "mq_context");
@@ -292,7 +292,7 @@ mq_context_t *client_make_context()
                             "min_ops_per_sec=100\n\t"
                             "socket_type=1002\n"; // Set socket type to MQF_ROUND_ROBIN
 
-    ifd = tbx_inip_string_read(text_parameters);
+    ifd = tbx_inip_read_string(text_parameters);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);
@@ -415,7 +415,7 @@ void bulk_worker_test(mq_context_t *mqc)
             log_printf(5, "WORKER: Success: n = %d, status = %d\n", current, status);
             success++;
         }
-        tbx_flush_log();
+        tbx_log_flush();
     }
 
     log_printf(5, "WORKER: Sleeping...\n");
@@ -443,7 +443,7 @@ mq_context_t *worker_make_context()
                             "min_ops_per_sec=100\n";
     // omitting socket_type for workers
 
-    ifd = tbx_inip_string_read(text_parameters);
+    ifd = tbx_inip_read_string(text_parameters);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);

--- a/src/gop/rr_mq_test.c
+++ b/src/gop/rr_mq_test.c
@@ -209,7 +209,7 @@ mq_context_t *server_make_context()
                             "socket_type=1002\n"; // Set socket type to MQF_ROUND_ROBIN
 
     tbx_log_flush();
-    ifd = tbx_inip_read_string(text_parameters);
+    ifd = tbx_inip_string_read(text_parameters);
 
     //log_printf(15, "SERVER: Creating context...\n");
     mqc = mq_create_context(ifd, "mq_context");
@@ -292,7 +292,7 @@ mq_context_t *client_make_context()
                             "min_ops_per_sec=100\n\t"
                             "socket_type=1002\n"; // Set socket type to MQF_ROUND_ROBIN
 
-    ifd = tbx_inip_read_string(text_parameters);
+    ifd = tbx_inip_string_read(text_parameters);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);
@@ -443,7 +443,7 @@ mq_context_t *worker_make_context()
                             "min_ops_per_sec=100\n";
     // omitting socket_type for workers
 
-    ifd = tbx_inip_read_string(text_parameters);
+    ifd = tbx_inip_string_read(text_parameters);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);

--- a/src/gop/rr_mq_worker.c
+++ b/src/gop/rr_mq_worker.c
@@ -402,7 +402,7 @@ mq_context_t *worker_make_context()
                             "min_ops_per_sec = 100\n";
     // omitting socket_type for workers
 
-    ifd = tbx_inip_read_string(text_parameters);
+    ifd = tbx_inip_string_read(text_parameters);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);

--- a/src/gop/rr_mq_worker.c
+++ b/src/gop/rr_mq_worker.c
@@ -216,10 +216,10 @@ void process_stream(mq_portal_t *p, mq_task_t *task, mq_msg_t *msg)
     memset(test_data, TEST_DATA, size_to_send);
 
     while(n_left > 0) {
-        n_bytes = tbx_random_int64(1, TEST_SIZE);
+        n_bytes = tbx_random_get_int64(1, TEST_SIZE);
         if(n_bytes > n_left)
             n_bytes = n_left;
-        offset = tbx_random_int64(0, size_to_send - n_bytes);
+        offset = tbx_random_get_int64(0, size_to_send - n_bytes);
 
         log_printf(5, "WORKER: n_sent = %d  offset = %d n_bytes = %d\n", n_sent, offset, n_bytes);
         err = mq_stream_write(mqs, &offset, sizeof(int));
@@ -402,7 +402,7 @@ mq_context_t *worker_make_context()
                             "min_ops_per_sec = 100\n";
     // omitting socket_type for workers
 
-    ifd = tbx_inip_string_read(text_parameters);
+    ifd = tbx_inip_read_string(text_parameters);
 
     mqc = mq_create_context(ifd, "mq_context");
     tbx_inip_destroy(ifd);
@@ -469,7 +469,7 @@ void worker_test()
     mq_context_t *mqc;
     //mq_command_table_t *table;
     //mq_portal_t *worker_portal;
-    tbx_flush_log();
+    tbx_log_flush();
     log_printf(1, "WORKER: Starting...\n");
 
     log_printf(10, "WORKER: Creating context...\n");

--- a/src/gop/thread_pool_config.c
+++ b/src/gop/thread_pool_config.c
@@ -108,7 +108,7 @@ void _tp_op_free(op_generic_t *gop, int mode)
     int id = gop_id(gop);
 
     log_printf(15, "_tp_op_free: mode=%d gid=%d gop=%p\n", mode, gop_id(gop), gop);
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (top->my_op_free != NULL) top->my_op_free(top->arg);
 
@@ -118,7 +118,7 @@ void _tp_op_free(op_generic_t *gop, int mode)
 
     if (mode == OP_DESTROY) free(gop->free_ptr);
     log_printf(15, "_tp_op_free: gid=%d END\n", id);
-    tbx_flush_log();
+    tbx_log_flush();
 
 }
 
@@ -313,7 +313,7 @@ void thread_pool_destroy_context(thread_pool_context_t *tpc)
     if (tpc->name != NULL) free(tpc->name);
 
     for (i=0; i<tpc->recursion_depth; i++) {
-        tbx_free_stack(tpc->reserve_stack[i], 0);
+        tbx_stack_free(tpc->reserve_stack[i], 0);
     }
     free(tpc->reserve_stack);
     free(tpc->overflow_running_depth);

--- a/src/gop/zmq_test.c
+++ b/src/gop/zmq_test.c
@@ -75,7 +75,7 @@ int socket_connect(void *socket, const char *format, ...)
     snprintf(buf, 255, format, args);
 //  snprintf(id, 255, "%s:%ld", buf, random());
 
-    snprintf(id, 255, "%ld", tbx_random_int64(1, 1000));
+    snprintf(id, 255, "%ld", tbx_random_get_int64(1, 1000));
     zsocket_set_identity(socket, strdup(id));
 
     err = zsocket_connect(socket, format, args);

--- a/src/ibp/ibp_config.c
+++ b/src/ibp/ibp_config.c
@@ -179,7 +179,7 @@ int ibp_rw_submit_coalesce(tbx_stack_t *stack, tbx_stack_ele_t *ele)
     tbx_stack_insert_below(&(rwc->list_stack), ele);
     iop->hp_parent = stack;
 
-    log_printf(15, "ibp_rw_submit_coalesce: gid=%d cap=%s count=%d\n", gop_id(gop), cmd->cap, tbx_stack_size(&(rwc->list_stack)));
+    log_printf(15, "ibp_rw_submit_coalesce: gid=%d cap=%s count=%d\n", gop_id(gop), cmd->cap, tbx_stack_count(&(rwc->list_stack)));
 
     apr_thread_mutex_unlock(ic->lock);
 
@@ -223,7 +223,7 @@ int ibp_rw_coalesce(op_generic_t *gop1)
         return(0);
     }
 
-    if (tbx_stack_size(&(rwc->list_stack)) == 1) { //** Nothing to do so exit
+    if (tbx_stack_count(&(rwc->list_stack)) == 1) { //** Nothing to do so exit
         ele = (tbx_stack_ele_t *)tbx_stack_pop(&(rwc->list_stack));  //** The top most task should be me
         gop2 = (op_generic_t *)tbx_stack_ele_get_data(ele);
         if (gop2 != gop1) {
@@ -239,10 +239,10 @@ int ibp_rw_coalesce(op_generic_t *gop1)
         return(0);
     }
 
-    log_printf(15, "ibp_rw_coalesce: gid=%d cap=%s count=%d\n", gop_id(gop1), cmd1->cap, tbx_stack_size(&(rwc->list_stack)));
+    log_printf(15, "ibp_rw_coalesce: gid=%d cap=%s count=%d\n", gop_id(gop1), cmd1->cap, tbx_stack_count(&(rwc->list_stack)));
 
     workload = 0;
-    n = tbx_stack_size(&(rwc->list_stack))+1;
+    n = tbx_stack_count(&(rwc->list_stack))+1;
     tbx_type_malloc(rwbuf, ibp_rw_buf_t *, n);
     pch = tbx_pch_reserve(ic->coalesced_gop_stacks);
     rwcg = (rwc_gop_stack_t *)tbx_pch_data(&pch);
@@ -330,14 +330,14 @@ int ibp_rw_coalesce(op_generic_t *gop1)
     }
 
     if (n > 0) log_printf(1, " Coalescing %d ops totaling " I64T " bytes  iov_sum=%d\n", n, workload, iov_sum);
-    if (tbx_stack_size(&(rwc->list_stack)) > 0) log_printf(1, "%d ops left on stack to coalesce\n", tbx_stack_size(&(rwc->list_stack)));
+    if (tbx_stack_count(&(rwc->list_stack)) > 0) log_printf(1, "%d ops left on stack to coalesce\n", tbx_stack_count(&(rwc->list_stack)));
 
     cmd1->n_ops = n;
     cmd1->n_tbx_iovec_total = iov_sum;
     cmd1->size = workload;
     gop1->op->cmd.workload = workload + ic->rw_new_command;
 
-    if (tbx_stack_size(&(rwc->list_stack)) == 0) {  //** Nothing left so free it
+    if (tbx_stack_count(&(rwc->list_stack)) == 0) {  //** Nothing left so free it
         tbx_list_remove(ic->coalesced_ops, cmd1->cap, NULL);
         tbx_pch_release(ic->coalesced_stacks, &(rwc->pch));
     }

--- a/src/ibp/ibp_config.c
+++ b/src/ibp/ibp_config.c
@@ -756,7 +756,7 @@ int ibp_load_config_file(ibp_context_t *ic, char *fname, char *section)
     int err;
 
     //* Load the config file
-    keyfile = tbx_inip_read_file(fname);
+    keyfile = tbx_inip_file_read(fname);
     if (keyfile == NULL) {
         log_printf(0, "Error parsing config file! file=%s\n", fname);
         return(-1);

--- a/src/ibp/ibp_find_drive.c
+++ b/src/ibp/ibp_find_drive.c
@@ -290,7 +290,7 @@ skip_submit:
     }
     opque_free(q, OP_DESTROY);
 
-    tbx_free_stack(tbuf_free, 0);
+    tbx_stack_free(tbuf_free, 0);
     free(tbuf_index);
     free(buf);
     free(buffer);

--- a/src/ibp/ibp_find_drive.c
+++ b/src/ibp/ibp_find_drive.c
@@ -217,7 +217,7 @@ double write_allocs(ibp_capset_t *caps, int qlen, int n, int asize, int block_si
 
     while (finished == 0) {
 //    nleft = qlen - opque_tasks_left(q);
-        nleft = tbx_stack_size(tbuf_free);
+        nleft = tbx_stack_count(tbuf_free);
 //    printf("\nLOOP: nleft=%d qlen=%d\n", nleft, qlen);
         if (nleft > 0) {
             for (j=block_start; j < nblocks; j++) {

--- a/src/ibp/ibp_op.c
+++ b/src/ibp/ibp_op.c
@@ -241,7 +241,7 @@ op_status_t gop_readline_with_timeout(tbx_ns_t *ns, char *buffer, int size, op_g
                 log_printf(15, "readline_with_timeout: END Client timeout time=" TT " end_time=" TT "ns=%d\n", apr_time_now(), end_time, tbx_ns_getid(ns));
             } else {
                 log_printf(0, "readline_with_timeout:  END Out of sync issue!! nbytes=%d size=%d ns=%d\n", nbytes, size, tbx_ns_getid(ns));
-                tbx_flush_log();
+                tbx_log_flush();
                 err = 0; //** GEnerate a core dump
 //           err = 1 / err;
             }
@@ -687,7 +687,7 @@ op_generic_t *new_ibp_write_op(ibp_context_t *ic, ibp_cap_t *cap, ibp_off_t offs
     op_generic_t *gop = new_ibp_rw_op(ic, IBP_WRITE, cap, offset, buffer, bpos, len, timeout);
 //   ibp_op_t *iop = ibp_get_iop(gop);
 
-//log_printf(15, "new_ibp_write_op: gid=%d next_block=%p\n", gop_id(gop), iop->ops.rw_op.next_block); tbx_flush_log();
+//log_printf(15, "new_ibp_write_op: gid=%d next_block=%p\n", gop_id(gop), iop->ops.rw_op.next_block); tbx_log_flush();
     return(gop);
 }
 
@@ -2335,7 +2335,7 @@ void set_ibp_probe_op(ibp_op_t *op, ibp_cap_t *cap, ibp_capstatus_t *probe, int 
     init_ibp_base_op(op, "probe", timeout, op->ic->other_new_command, NULL, 1, IBP_MANAGE, IBP_PROBE);
 
     log_printf(15, "AFTER cctype=%d\n", op->ic->cc[IBP_MANAGE].type);
-    tbx_flush_log();
+    tbx_log_flush();
 
     cmd = &(op->ops.probe_op);
 
@@ -3125,12 +3125,12 @@ op_status_t query_res_recv(op_generic_t *gop, tbx_ns_t *ns)
     ridlist_init(cmd->rlist, n);
     tbx_stack_move_to_bottom(list);
     for (i=0; i<n; i++) {
-        p = tbx_get_ele_data(list);
+        p = tbx_stack_get_current_data(list);
         cmd->rlist->rl[i] = ibp_str2rid(p);
         tbx_stack_move_up(list);
     }
 
-    tbx_free_stack(list, 0);
+    tbx_stack_free(list, 0);
 
     return(err);
 }

--- a/src/ibp/ibp_op.c
+++ b/src/ibp/ibp_op.c
@@ -3121,7 +3121,7 @@ op_status_t query_res_recv(op_generic_t *gop, tbx_ns_t *ns)
         p = tbx_stk_string_token(NULL, " ", &bstate, &fin);
     }
 
-    n = tbx_stack_size(list);
+    n = tbx_stack_count(list);
     ridlist_init(cmd->rlist, n);
     tbx_stack_move_to_bottom(list);
     for (i=0; i<n; i++) {

--- a/src/ibp/ibp_sync.c
+++ b/src/ibp/ibp_sync.c
@@ -118,7 +118,7 @@ int ibp_sync_command(ibp_op_t *iop)
         gop->op->cmd.hostport = NULL;
     }
 
-    log_printf(10, "ibp_sync_command: IBP_errno=%d\n", IBP_errno); //tbx_flush_log();
+    log_printf(10, "ibp_sync_command: IBP_errno=%d\n", IBP_errno); //tbx_log_flush();
 
     return(IBP_errno);
 }

--- a/src/ibp/io_wrapper.c
+++ b/src/ibp/io_wrapper.c
@@ -80,7 +80,7 @@ int io_waitall(opque_t *q)
         }
 
         log_printf(15, "io_waitall: err=%d nfailed=%d nleft=%d\n", err, opque_tasks_failed(q), opque_tasks_left(q));
-//tbx_flush_log();
+//tbx_log_flush();
     }
 
     return(err);

--- a/src/ibp/iovec_sync.c
+++ b/src/ibp/iovec_sync.c
@@ -37,7 +37,7 @@ int ibp_sync_execute(opque_t *q, int nthreads)
     tbx_stack_t *tasks;
     op_generic_t *gop;
 
-    log_printf(15, "ibp_sync_execute: Start! ncommands=%d\n", tbx_stack_size(q->qd.list));
+    log_printf(15, "ibp_sync_execute: Start! ncommands=%d\n", tbx_stack_count(q->qd.list));
     default_sort_ops(NULL, q);
 
     q = new_opque();

--- a/src/ibp/phoebus.c
+++ b/src/ibp/phoebus.c
@@ -207,7 +207,7 @@ void phoebus_load_config(tbx_inip_file_t *kf)
 {
 if (global_phoebus == NULL) phoebus_init();
  
-char *gateway = tbx_inip_string_get(kf, "phoebus", "gateway", NULL);
+char *gateway = tbx_inip_get_string(kf, "phoebus", "gateway", NULL);
  
 if (gateway != NULL) {
 phoebus_path_set(global_phoebus, gateway);

--- a/src/lio/arc_create.c
+++ b/src/lio/arc_create.c
@@ -259,7 +259,7 @@ int process_tag_file(char *tag_file, char *tag_name)
         exit(1);
     } else {
         /*** process tag file ***/
-        ini_fd = tbx_inip_read_file(tag_file); assert(ini_fd);
+        ini_fd = tbx_inip_file_read(tag_file); assert(ini_fd);
         ini_g = tbx_inip_group_first(ini_fd);
         obj_types = OS_OBJECT_ANY;
         while (ini_g != NULL) {

--- a/src/lio/arc_create.c
+++ b/src/lio/arc_create.c
@@ -259,15 +259,15 @@ int process_tag_file(char *tag_file, char *tag_name)
         exit(1);
     } else {
         /*** process tag file ***/
-        ini_fd = tbx_inip_file_read(tag_file); assert(ini_fd);
+        ini_fd = tbx_inip_read_file(tag_file); assert(ini_fd);
         ini_g = tbx_inip_group_first(ini_fd);
         obj_types = OS_OBJECT_ANY;
         while (ini_g != NULL) {
             if (strcmp(tbx_inip_group_get(ini_g), "TAG") == 0) {
                 ele = tbx_inip_ele_first(ini_g);
                 while (ele != NULL) {
-                    key = tbx_inip_ele_key_get(ele);
-                    value = tbx_inip_ele_value_get(ele);
+                    key = tbx_inip_ele_get_key(ele);
+                    value = tbx_inip_ele_get_value(ele);
                     if (strcmp(key, "name") == 0) {
                         name = value;
                     } else if (strcmp(key, "path") == 0) {

--- a/src/lio/arc_tag_ls.c
+++ b/src/lio/arc_tag_ls.c
@@ -115,7 +115,7 @@ void process_tag_file(char *tag_file, char *tag_name)
         exit(1);
     } else {
         /*** process tag file ***/
-        ini_fd = tbx_inip_read_file(tag_file); assert(ini_fd);
+        ini_fd = tbx_inip_file_read(tag_file); assert(ini_fd);
         ini_g = tbx_inip_group_first(ini_fd);
         obj_types = OS_OBJECT_ANY;
         while (ini_g != NULL) {

--- a/src/lio/arc_tag_ls.c
+++ b/src/lio/arc_tag_ls.c
@@ -115,15 +115,15 @@ void process_tag_file(char *tag_file, char *tag_name)
         exit(1);
     } else {
         /*** process tag file ***/
-        ini_fd = tbx_inip_file_read(tag_file); assert(ini_fd);
+        ini_fd = tbx_inip_read_file(tag_file); assert(ini_fd);
         ini_g = tbx_inip_group_first(ini_fd);
         obj_types = OS_OBJECT_ANY;
         while (ini_g != NULL) {
             if (strcmp(tbx_inip_group_get(ini_g), "TAG") == 0) {
                 ele = tbx_inip_ele_first(ini_g);
                 while (ele != NULL) {
-                    key = tbx_inip_ele_key_get(ele);
-                    value = tbx_inip_ele_value_get(ele);
+                    key = tbx_inip_ele_get_key(ele);
+                    value = tbx_inip_ele_get_value(ele);
                     if (strcmp(key, "name") == 0) {
                         name = value;
                     } else if (strcmp(key, "path") == 0) {

--- a/src/lio/cache_amp.c
+++ b/src/lio/cache_amp.c
@@ -64,7 +64,7 @@ void print_cache_table(int dolock)
     if (dolock) cache_lock(c);
 
     log_printf(ll, "Checking table.  n_pages=%d top=%p bottom=%p\n", tbx_stack_size(cp->stack), cp->stack->top, cp->stack->bottom);
-    tbx_flush_log();
+    tbx_log_flush();
     if (cp->stack->top != NULL) {
         p = (cache_page_t *)cp->stack->top->data;
         log_printf(11, "top: p=%p   p->seg=" XIDT " p->offset=" XOT "\n", p, segment_id(p->seg), p->offset);
@@ -79,23 +79,23 @@ void print_cache_table(int dolock)
     if ( cp->stack->top == NULL) {
         if (cp->stack->bottom != NULL) {
             log_printf(ll, "ERROR: top=NULL bottom=%p\n", cp->stack->bottom);
-            tbx_flush_log();
+            tbx_log_flush();
         }
         goto finished;
     }
 
     tbx_stack_move_to_top(cp->stack);
-    ele = tbx_get_ptr(cp->stack);
-    p = (cache_page_t *)tbx_get_stack_ele_data(ele);
+    ele = tbx_stack_get_current_ptr(cp->stack);
+    p = (cache_page_t *)tbx_stack_ele_get_data(ele);
     p0 = p;
     n++;
     tbx_stack_move_down(cp->stack);
-    while ((ele = tbx_get_ptr(cp->stack)) != NULL) {
+    while ((ele = tbx_stack_get_current_ptr(cp->stack)) != NULL) {
         n++;
-        p = (cache_page_t *)tbx_get_stack_ele_data(ele);
+        p = (cache_page_t *)tbx_stack_ele_get_data(ele);
         if (p0->seg != p->seg) {
             log_printf(ll, "ERROR p0->seg=" XIDT " p->seg=" XIDT " n=%d\n", segment_id(p0->seg), segment_id(p->seg), n);
-            tbx_flush_log();
+            tbx_log_flush();
         }
         tbx_stack_move_down(cp->stack);
     }
@@ -104,7 +104,7 @@ void print_cache_table(int dolock)
     p = (cache_page_t *)cp->stack->bottom->data;
     if (p0 != p) {
         log_printf(ll, "ERROR bottom(%p) != last page(%p) n=%d\n", p, p0, n);
-        tbx_flush_log();
+        tbx_log_flush();
         log_printf(ll, "ERROR bottom->seg=" XIDT " last->seg=" XIDT "\n", segment_id(p->seg), segment_id(p0->seg));
         log_printf(ll, "ERROR bottom->off=" XOT " last->off=" XOT "\n", p->offset, p0->offset);
     }
@@ -112,7 +112,7 @@ void print_cache_table(int dolock)
 finished:
     if (n != tbx_stack_size(cp->stack)) {
         log_printf(ll, "ERROR:  missing pages!  n=%d stack=%d\n", n, tbx_stack_size(cp->stack));
-        tbx_flush_log();
+        tbx_log_flush();
     }
 
     if (dolock) cache_unlock(c);
@@ -241,7 +241,7 @@ void *amp_dirty_thread(apr_thread_t *th, void *data)
         i = 0;
         while (id != NULL) {
             log_printf(15, "Flushing seg=" XIDT " i=%d\n", *id, i);
-            tbx_flush_log();
+            tbx_log_flush();
             flush_list[i] = seg;
             s = (cache_segment_t *)seg->priv;
             s->cache_check_in_progress++;  //** Flag it as being checked
@@ -261,7 +261,7 @@ void *amp_dirty_thread(apr_thread_t *th, void *data)
             s = (cache_segment_t *)flush_list[i]->priv;
 
             log_printf(15, "Flush completed seg=" XIDT " i=%d\n", segment_id(flush_list[i]), i);
-            tbx_flush_log();
+            tbx_log_flush();
             cache_lock(c);
             s->cache_check_in_progress--;  //** Flag it as being finished
             cache_unlock(c);
@@ -335,7 +335,7 @@ cache_page_t *_amp_new_page(cache_t *c, segment_t *seg)
 
     //** Store my position
     tbx_stack_push(cp->stack, p);
-    lp->ele = tbx_get_ptr(cp->stack);
+    lp->ele = tbx_stack_get_current_ptr(cp->stack);
 
     log_printf(_amp_logging, " seg=" XIDT " MRU page created initial->offset=" XOT " page_size=" XOT " bytes_used=" XOT " stack_size=%d\n", segment_id(seg), p->offset, s->page_size, cp->bytes_used, tbx_stack_size(cp->stack));
     return(p);
@@ -364,19 +364,19 @@ void _amp_process_waiters(cache_t *c)
         bytes_free = _amp_max_bytes(c) - cp->bytes_used;
 
         tbx_stack_move_to_top(cp->waiting_stack);
-        pw = tbx_get_ele_data(cp->waiting_stack);
+        pw = tbx_stack_get_current_data(cp->waiting_stack);
         bytes_needed = pw->bytes_needed;
         log_printf(15, "START free=" XOT " needed=" XOT "\n", bytes_free, bytes_needed);
 
         while ((bytes_needed <= bytes_free) && (pw != NULL)) {
             bytes_free -= bytes_needed;
-            tbx_delete_current(cp->waiting_stack, 1, 0);
+            tbx_stack_delete_current(cp->waiting_stack, 1, 0);
             log_printf(15, "waking up waiting stack pw=%p\n", pw);
 
             apr_thread_cond_signal(pw->cond);    //** Wake up the paused thread
 
             //** Get the next one if available
-            pw = tbx_get_ele_data(cp->waiting_stack);
+            pw = tbx_stack_get_current_data(cp->waiting_stack);
             bytes_needed = (pw == NULL) ? bytes_free + 1 : pw->bytes_needed;
         }
     }
@@ -576,7 +576,7 @@ void _amp_prefetch(segment_t *seg, ex_off_t lo, ex_off_t hi, int start_prefetch,
     gop = new_thread_pool_op(s->tpc_unlimited, NULL, amp_prefetch_fn, (void *)ca, free, 1);
     ca->gop = gop;
 //log_printf(15, "tid=%d seg=" XIDT " lo=" XOT " hi=" XOT " rw_mode=%d ca=%p gid=%d\n", tid, segment_id(seg), lo, hi, rw_mode, ca, gop_id(gop));
-//tbx_flush_log();
+//tbx_log_flush();
 
     gop_set_auto_destroy(gop, 1);
 
@@ -608,7 +608,7 @@ int _amp_pages_release(cache_t *c, cache_page_t **page, int n_pages)
             cp->bytes_used -= s->page_size;
             if (lp->ele != NULL) {
                 tbx_stack_move_to_ptr(cp->stack, lp->ele);
-                tbx_delete_current(cp->stack, 0, 0);
+                tbx_stack_delete_current(cp->stack, 0, 0);
             } else {
                 cp->limbo_pages--;
                 log_printf(15, "seg=" XIDT " limbo page p->offset=" XOT " limbo=%d\n", segment_id(p->seg), p->offset, cp->limbo_pages);
@@ -661,7 +661,7 @@ void _amp_pages_destroy(cache_t *c, cache_page_t **page, int n_pages, int remove
 
             if (lp->ele != NULL) {
                 tbx_stack_move_to_ptr(cp->stack, lp->ele);
-                tbx_delete_current(cp->stack, 0, 0);
+                tbx_stack_delete_current(cp->stack, 0, 0);
             }
 
             if (remove_from_segment == 1) {
@@ -708,7 +708,7 @@ int _amp_page_access(cache_t *c, cache_page_t *p, int rw_mode, ex_off_t request_
             tbx_stack_move_to_ptr(cp->stack, lp->ele);
             tbx_stack_unlink_current(cp->stack, 1);
             tbx_stack_move_to_top(cp->stack);
-            tbx_stack_insert_link_above(cp->stack, lp->ele);
+            tbx_stack_link_insert_above(cp->stack, lp->ele);
         }
 
         if (rw_mode == CACHE_WRITE) {  //** Write update so return
@@ -780,9 +780,9 @@ int _amp_free_mem(cache_t *c, segment_t *pseg, ex_off_t bytes_to_free)
     log_printf(_amp_logging, "START seg=" XIDT " bytes_to_free=" XOT " bytes_used=" XOT " stack_size=%d\n", segment_id(pseg), bytes_to_free, cp->bytes_used, tbx_stack_size(cp->stack));
 
     tbx_stack_move_to_bottom(cp->stack);
-    ele = tbx_get_ptr(cp->stack);
+    ele = tbx_stack_get_current_ptr(cp->stack);
     while ((total_bytes < bytes_to_free) && (ele != NULL) && (err == 0)) {
-        p = (cache_page_t *)tbx_get_stack_ele_data(ele);
+        p = (cache_page_t *)tbx_stack_ele_get_data(ele);
         lp = (page_amp_t *)p->priv;
         if ((p->bit_fields & C_TORELEASE) == 0) { //** Skip it if already flagged for removal
             count = p->access_pending[CACHE_READ] + p->access_pending[CACHE_WRITE] + p->access_pending[CACHE_FLUSH];
@@ -792,7 +792,7 @@ int _amp_free_mem(cache_t *c, segment_t *pseg, ex_off_t bytes_to_free)
                     total_bytes += s->page_size;
                     log_printf(_amp_logging, "amp_free_mem: freeing page seg=" XIDT " p->offset=" XOT " bits=%d\n", segment_id(p->seg), p->offset, p->bit_fields);
                     tbx_list_remove(s->pages, &(p->offset), p);  //** Have to do this here cause p->offset is the key var
-                    tbx_delete_current(cp->stack, 1, 0);
+                    tbx_stack_delete_current(cp->stack, 1, 0);
                     if (p->data[0].ptr) free(p->data[0].ptr);
                     if (p->data[1].ptr) free(p->data[1].ptr);
                     free(lp);
@@ -806,7 +806,7 @@ int _amp_free_mem(cache_t *c, segment_t *pseg, ex_off_t bytes_to_free)
             tbx_stack_move_up(cp->stack);
         }
 
-        ele = tbx_get_ptr(cp->stack);
+        ele = tbx_stack_get_current_ptr(cp->stack);
     }
 
     cp->bytes_used -= total_bytes;
@@ -852,14 +852,14 @@ ex_off_t _amp_attempt_free_mem(cache_t *c, segment_t *page_seg, ex_off_t bytes_t
 
     //** Get the list of pages to free
     tbx_stack_move_to_bottom(cp->stack);
-    ele = tbx_get_ptr(cp->stack);
+    ele = tbx_stack_get_current_ptr(cp->stack);
     while ((total_bytes < bytes_to_free) && (ele != NULL)) {
-        p = (cache_page_t *)tbx_get_stack_ele_data(ele);
+        p = (cache_page_t *)tbx_stack_ele_get_data(ele);
         lp = (page_amp_t *)p->priv;
         s = (cache_segment_t *)p->seg->priv;
 
         log_printf(15, "checking page for release seg=" XIDT " p->offset=" XOT " bits=%d\n", segment_id(p->seg), p->offset, p->bit_fields);
-        tbx_flush_log();
+        tbx_log_flush();
 
         if ((p->bit_fields & C_TORELEASE) == 0) { //** Skip it if already flagged for removal
             if ((lp->bit_fields & (CAMP_OLD|CAMP_ACCESSED)) > 0) {  //** Already used once or cycled so ok to evict
@@ -872,7 +872,7 @@ ex_off_t _amp_attempt_free_mem(cache_t *c, segment_t *page_seg, ex_off_t bytes_t
                         freed_bytes += s->page_size;
                         log_printf(_amp_logging, "freeing page seg=" XIDT " p->offset=" XOT " bits=%d\n", segment_id(p->seg), p->offset, p->bit_fields);
                         tbx_list_remove(s->pages, &(p->offset), p);  //** Have to do this here cause p->offset is the key var
-                        tbx_delete_current(cp->stack, 1, 0);
+                        tbx_stack_delete_current(cp->stack, 1, 0);
                         if (p->data[0].ptr) free(p->data[0].ptr);
                         if (p->data[1].ptr) free(p->data[1].ptr);
                         free(lp);
@@ -916,9 +916,9 @@ ex_off_t _amp_attempt_free_mem(cache_t *c, segment_t *page_seg, ex_off_t bytes_t
                 log_printf(_amp_logging, "seg=" XIDT " MRU retry offset=" XOT "\n", segment_id(p->seg), p->offset);
 
                 tbx_stack_unlink_current(cp->stack, 1);  //** and move it to the MRU slot.  This is ele
-                curr_ele = tbx_get_ptr(cp->stack);
+                curr_ele = tbx_stack_get_current_ptr(cp->stack);
                 tbx_stack_move_to_top(cp->stack);
-                tbx_stack_insert_link_above(cp->stack, lp->ele);
+                tbx_stack_link_insert_above(cp->stack, lp->ele);
                 tbx_stack_move_to_ptr(cp->stack, curr_ele);
 
                 //** Tweak the stream info
@@ -934,7 +934,7 @@ ex_off_t _amp_attempt_free_mem(cache_t *c, segment_t *page_seg, ex_off_t bytes_t
         }
 
         total_bytes = freed_bytes + pending_bytes;
-        if (total_bytes < bytes_to_free) ele = tbx_get_ptr(cp->stack);
+        if (total_bytes < bytes_to_free) ele = tbx_stack_get_current_ptr(cp->stack);
     }
 
 
@@ -1293,7 +1293,7 @@ int amp_cache_destroy(cache_t *c)
     cache_amp_t *cp = (cache_amp_t *)c->fn.priv;
 
     log_printf(15, "Shutting down\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Shutdown the dirty thread
     cache_lock(c);
@@ -1304,7 +1304,7 @@ int amp_cache_destroy(cache_t *c)
     apr_thread_join(&value, cp->dirty_thread);  //** Wait for it to complete
 
     log_printf(15, "Dirty thread has completed\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     cache_base_destroy(c);
 
@@ -1314,19 +1314,19 @@ int amp_cache_destroy(cache_t *c)
         tbx_stack_move_to_top(cp->stack);
         n = 0;
         tbx_stack_move_down(cp->stack);
-        while ((ele = tbx_get_ptr(cp->stack)) != NULL) {
+        while ((ele = tbx_stack_get_current_ptr(cp->stack)) != NULL) {
             n++;
-            p = (cache_page_t *)tbx_get_stack_ele_data(ele);
+            p = (cache_page_t *)tbx_stack_ele_get_data(ele);
             log_printf(0, "ERROR n=%d p->seg=" XIDT " offset=" XOT "\n", n, segment_id(p->seg), p->offset);
-            tbx_flush_log();
+            tbx_log_flush();
             tbx_stack_move_down(cp->stack);
         }
         log_printf(0, "-------------------\n");
     }
 
-    tbx_free_stack(cp->stack, 1);
-    tbx_free_stack(cp->waiting_stack, 0);
-    tbx_free_stack(cp->pending_free_tasks, 0);
+    tbx_stack_free(cp->stack, 1);
+    tbx_stack_free(cp->waiting_stack, 0);
+    tbx_stack_free(cp->pending_free_tasks, 0);
 
     tbx_pc_destroy(cp->free_pending_tables);
     tbx_pc_destroy(cp->free_page_tables);
@@ -1416,20 +1416,20 @@ cache_t *amp_cache_load(void *arg, tbx_inip_file_t *fd, char *grp, data_attr_t *
     global_cache = c;
 
     cache_lock(c);
-    cp->max_bytes = tbx_inip_integer_get(fd, grp, "max_bytes", cp->max_bytes);
-    cp->max_streams = tbx_inip_integer_get(fd, grp, "max_streams", cp->max_streams);
-    cp->dirty_fraction = tbx_inip_double_get(fd, grp, "dirty_fraction", cp->dirty_fraction);
+    cp->max_bytes = tbx_inip_get_integer(fd, grp, "max_bytes", cp->max_bytes);
+    cp->max_streams = tbx_inip_get_integer(fd, grp, "max_streams", cp->max_streams);
+    cp->dirty_fraction = tbx_inip_get_double(fd, grp, "dirty_fraction", cp->dirty_fraction);
     cp->dirty_bytes_trigger = cp->dirty_fraction * cp->max_bytes;
-    c->default_page_size = tbx_inip_integer_get(fd, grp, "default_page_size", c->default_page_size);
-    cp->async_prefetch_threshold = tbx_inip_integer_get(fd, grp, "async_prefetch_threshold", cp->async_prefetch_threshold);
-    cp->min_prefetch_size = tbx_inip_integer_get(fd, grp, "min_prefetch_bytes", cp->min_prefetch_size);
-    dt = tbx_inip_integer_get(fd, grp, "dirty_max_wait", apr_time_sec(cp->dirty_max_wait));
+    c->default_page_size = tbx_inip_get_integer(fd, grp, "default_page_size", c->default_page_size);
+    cp->async_prefetch_threshold = tbx_inip_get_integer(fd, grp, "async_prefetch_threshold", cp->async_prefetch_threshold);
+    cp->min_prefetch_size = tbx_inip_get_integer(fd, grp, "min_prefetch_bytes", cp->min_prefetch_size);
+    dt = tbx_inip_get_integer(fd, grp, "dirty_max_wait", apr_time_sec(cp->dirty_max_wait));
     cp->dirty_max_wait = apr_time_make(dt, 0);
-    c->max_fetch_fraction = tbx_inip_double_get(fd, grp, "max_fetch_fraction", c->max_fetch_fraction);
+    c->max_fetch_fraction = tbx_inip_get_double(fd, grp, "max_fetch_fraction", c->max_fetch_fraction);
     c->max_fetch_size = c->max_fetch_fraction * cp->max_bytes;
-    c->write_temp_overflow_fraction = tbx_inip_double_get(fd, grp, "write_temp_overflow_fraction", c->write_temp_overflow_fraction);
+    c->write_temp_overflow_fraction = tbx_inip_get_double(fd, grp, "write_temp_overflow_fraction", c->write_temp_overflow_fraction);
     c->write_temp_overflow_size = c->write_temp_overflow_fraction * cp->max_bytes;
-    c->n_ppages = tbx_inip_integer_get(fd, grp, "ppages", c->n_ppages);
+    c->n_ppages = tbx_inip_get_integer(fd, grp, "ppages", c->n_ppages);
 
     cache_unlock(c);
 

--- a/src/lio/cache_base.c
+++ b/src/lio/cache_base.c
@@ -96,7 +96,7 @@ void free_page_tables_free(void *arg, int size, void *data)
     log_printf(15, "destroying shelf of size %d\n", size);
 
     for (i=0; i<size; i++) {
-        tbx_free_stack(shelf[i].stack, 0);
+        tbx_stack_free(shelf[i].stack, 0);
     }
 
     free(shelf);
@@ -121,7 +121,7 @@ void *free_pending_table_new(void *arg, int size)
     }
 
     log_printf(15, " shelf[0]->max_levels=%d\n", shelf[0]->max_levels);
-    tbx_flush_log();
+    tbx_log_flush();
     return((void *)shelf);
 }
 

--- a/src/lio/cache_round_robin.c
+++ b/src/lio/cache_round_robin.c
@@ -56,7 +56,7 @@ int rr_cache_destroy(cache_t *c)
     cache_rr_t *cp = (cache_rr_t *)c->fn.priv;
 
     log_printf(15, "Shutting down\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     for (i=0; i<cp->n_cache; i++) {
         cache_destroy(cp->child[i]);
@@ -116,9 +116,9 @@ cache_t *round_robin_cache_load(void *arg, tbx_inip_file_t *fd, char *grp, data_
     cp = (cache_rr_t *)c->fn.priv;
 
     cache_lock(c);
-    cp->n_cache = tbx_inip_integer_get(fd, grp, "n_cache", 2);
-    child_section = tbx_inip_string_get(fd, grp, "child", "cache-amp");
-    ctype = tbx_inip_string_get(fd, child_section, "type", NULL);
+    cp->n_cache = tbx_inip_get_integer(fd, grp, "n_cache", 2);
+    child_section = tbx_inip_get_string(fd, grp, "child", "cache-amp");
+    ctype = tbx_inip_get_string(fd, child_section, "type", NULL);
 
     tbx_type_malloc(cp->child, cache_t *, cp->n_cache);
     for (i=0; i<cp->n_cache; i++) {

--- a/src/lio/ds_ibp.c
+++ b/src/lio/ds_ibp.c
@@ -542,7 +542,7 @@ void _ds_ibp_op_free(op_generic_t *gop, int mode)
     ds_ibp_op_t *iop = gop->free_ptr;
 
 //log_printf(0, "Freeing gid=%d\n", gop_id(gop));
-//tbx_flush_log();
+//tbx_log_flush();
 
     //** Call the original cleanup routine
     gop->free_ptr = iop->free_ptr;
@@ -951,21 +951,21 @@ data_service_fn_t *ds_ibp_create(void *arg, tbx_inip_file_t *ifd, char *section)
 
     //** Set the default attributes
     memset(&(ds->attr_default), 0, sizeof(ds_ibp_attr_t));
-    ds->attr_default.attr.duration = tbx_inip_integer_get(ifd, section, "duration", 3600);
+    ds->attr_default.attr.duration = tbx_inip_get_integer(ifd, section, "duration", 3600);
 
     ds->warm_duration = ds->attr_default.attr.duration;
     ds->warm_interval = 0.33 * ds->warm_duration;
-    ds->warm_interval = tbx_inip_integer_get(ifd, section, "warm_interval", ds->warm_interval);
-    ds->warm_duration = tbx_inip_integer_get(ifd, section, "warm_duration", ds->warm_duration);
+    ds->warm_interval = tbx_inip_get_integer(ifd, section, "warm_interval", ds->warm_interval);
+    ds->warm_duration = tbx_inip_get_integer(ifd, section, "warm_duration", ds->warm_duration);
 
-    cs_type = tbx_inip_integer_get(ifd, section, "chksum_type", CHKSUM_DEFAULT);
+    cs_type = tbx_inip_get_integer(ifd, section, "chksum_type", CHKSUM_DEFAULT);
     if ( ! ((tbx_chksum_type_valid(cs_type) == 0) || (cs_type == CHKSUM_DEFAULT) || (cs_type == CHKSUM_NONE)))  {
         log_printf(0, "Invalid chksum type=%d resetting to CHKSUM_DEFAULT(%d)\n", cs_type, CHKSUM_DEFAULT);
         cs_type = CHKSUM_DEFAULT;
     }
     ds->attr_default.disk_cs_type = cs_type;
 
-    ds->attr_default.disk_cs_blocksize = tbx_inip_integer_get(ifd, section, "chksum_blocksize", 64*1024);
+    ds->attr_default.disk_cs_blocksize = tbx_inip_get_integer(ifd, section, "chksum_blocksize", 64*1024);
     if (ds->attr_default.disk_cs_blocksize <= 0) {
         log_printf(0, "Invalid chksum blocksize=%d resetting to %d\n", ds->attr_default.disk_cs_blocksize, 64*1024);
         ds->attr_default.disk_cs_blocksize = 64 *1024;

--- a/src/lio/ex_get.c
+++ b/src/lio/ex_get.c
@@ -145,10 +145,10 @@ int main(int argc, char **argv)
         tbx_tbuf_single(&tbuf, rlen, rbuf);
         ex_iovec_single(&iov, i, rlen);
         log_printf(1, "ex_get: i=" XOT " rlen=" XOT " wlen=" XOT "\n", i, rlen, wlen);
-        tbx_flush_log();
+        tbx_log_flush();
         gop = segment_read(seg, lio_gc->da, NULL, 1, &iov, &tbuf, 0, 5);
         log_printf(1, "ex_get: i=" XOT " gid=%d\n", i, gop_id(gop));
-        tbx_flush_log();
+        tbx_log_flush();
 
         //** Dump the data to disk
         if (firsttime == 0) {

--- a/src/lio/ex_id.c
+++ b/src/lio/ex_id.c
@@ -27,7 +27,7 @@
 void generate_ex_id(ex_id_t *id)
 {
     //** Fill with random data
-    tbx_random_bytes_get(id, sizeof(ex_id_t));
+    tbx_random_get_bytes(id, sizeof(ex_id_t));
 
     //** Mask the sign bit cause JAVA doesn't like unsigned numbers
     *id = (*id) << 1;

--- a/src/lio/ex_inspect.c
+++ b/src/lio/ex_inspect.c
@@ -134,9 +134,9 @@ int main(int argc, char **argv)
     printf("whattodo=%d\n", whattodo);
     //** Execute the inspection operation
     gop = segment_inspect(seg, lio_gc->da, lio_ifd, whattodo, bufsize, NULL, lio_gc->timeout);
-    tbx_flush_log();
+    tbx_log_flush();
     gop_waitany(gop);
-    tbx_flush_log();
+    tbx_log_flush();
     status = gop_get_status(gop);
     gop_free(gop, OP_DESTROY);
 

--- a/src/lio/ex_put.c
+++ b/src/lio/ex_put.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         gop_start_execution(gop);
 
         log_printf(1, "ex_put: i=" XOT " gid=%d\n", i, gop_id(gop));
-        tbx_flush_log();
+        tbx_log_flush();
 
         //** Read in the next block
         disk_start = apr_time_now();
@@ -162,10 +162,10 @@ int main(int argc, char **argv)
 
         err = gop_waitall(gop);
         log_printf(1, "ex_put: i=" XOT " gid=%d err=%d\n", i, gop_id(gop), err);
-        tbx_flush_log();
+        tbx_log_flush();
         if (err != OP_STATE_SUCCESS) {
             printf("ex_put: Error writing offset=" XOT " wlen=" XOT "!\n",i, wlen);
-            tbx_flush_log();
+            tbx_log_flush();
             fflush(stdout);
             abort();
         }
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
 
     //** Flush everything to backing store
     log_printf(1, "Flushing to disk size=" XOT "\n", segment_size(seg));
-    tbx_flush_log();
+    tbx_log_flush();
     gop_sync_exec(segment_flush(seg, lio_gc->da, 0, segment_size(seg)+1, lio_gc->timeout));
     log_printf(1, "Flush completed\n");
     cumulative_time = apr_time_now() - start_time;

--- a/src/lio/ex_rw_test.c
+++ b/src/lio/ex_rw_test.c
@@ -747,7 +747,7 @@ void rw_test()
             tbx_stack_push(free_slots, slot);
         }
 
-        if ((tbx_stack_size(free_slots) == 0) || (gop == NULL)) {
+        if ((tbx_stack_count(free_slots) == 0) || (gop == NULL)) {
             gop = opque_waitany(q);
 
             slot = gop_get_private(gop);

--- a/src/lio/ex_rw_test.c
+++ b/src/lio/ex_rw_test.c
@@ -883,7 +883,7 @@ void rw_load_options(char *cfgname, char *group)
     tbx_inip_file_t *fd;
     char *str;
 
-    fd = tbx_inip_read_file(cfgname);
+    fd = tbx_inip_file_read(cfgname);
     if (fd == NULL) {
         printf("rw_load_config:  ERROR opening config file: %s\n", cfgname);
         tbx_log_flush();

--- a/src/lio/ex_rw_test.c
+++ b/src/lio/ex_rw_test.c
@@ -106,7 +106,7 @@ void my_random_seed(unsigned int seed)
 
 //*************************************************************************
 
-int my_tbx_random_bytes_get(void *vbuf, int nbytes)
+int my_tbx_random_get_bytes(void *vbuf, int nbytes)
 {
     char *buf = (char *)vbuf;
     int i;
@@ -142,7 +142,7 @@ double my_random_double(double lo, double hi)
     uint64_t rn;
 
     rn = 0;
-    my_tbx_random_bytes_get(&rn, sizeof(rn));
+    my_tbx_random_get_bytes(&rn, sizeof(rn));
 //log_printf(10, "my_random_double: rn=" XIDT "\n", rn);
     dn = (1.0 * rn) / (UINT64_MAX + 1.0);
 //  dn = rn;
@@ -158,7 +158,7 @@ double my_random_double(double lo, double hi)
 
 //*******************************************************************
 
-int64_t my_tbx_random_int64(int64_t lo, int64_t hi)
+int64_t my_tbx_random_get_int64(int64_t lo, int64_t hi)
 {
     int64_t n, dn;
 
@@ -253,7 +253,7 @@ void generate_task_list()
 
     //** Make the actual buffer and fill it with random data
     tbx_type_malloc_clear(tile_data, char, tile_bytes);
-    my_tbx_random_bytes_get(tile_data, tile_bytes);
+    my_tbx_random_get_bytes(tile_data, tile_bytes);
 
     //** Make the array defining the order or operations
     tbx_type_malloc(tile_index, int, tile_size);
@@ -396,14 +396,14 @@ void perform_final_verify()
     off = 0;
     fail = 0;
     log_printf(0, "-------------- Starting final verify -----------------------\n");
-    tbx_flush_log();
+    tbx_log_flush();
     dt = apr_time_now();
 
     for (i=0; i<n; i++) {
         log_printf(ll, "checking offset=" XOT "\n", off);
         memset(buffer, 'A', tile_bytes);
         ex_iovec_single(&iov, off, tile_bytes);
-        tbx_flush_log();
+        tbx_log_flush();
         dt2 = apr_time_now();
 
         err = gop_sync_exec(segment_read(seg, da, NULL, 1, &iov, &tbuf, 0, rwc.timeout));
@@ -414,14 +414,14 @@ void perform_final_verify()
         log_printf(0, "gop er=%d: Time: %lf secs  (%lf MB/s)\n", err, dsec, rate);
 
         log_printf(ll, "gop err=%d\n", err);
-        tbx_flush_log();
+        tbx_log_flush();
 
         if (err != OP_STATE_SUCCESS) {
             log_printf(0, "ERROR with read! block offset=" XOT "\n", off);
         }
         err = memcmp(buffer, tile_data, tile_bytes);
         log_printf(ll, "memcmp=%d\n", err);
-        tbx_flush_log();
+        tbx_log_flush();
 
 //err = 0;
         if (err != 0) {
@@ -465,7 +465,7 @@ void perform_final_verify()
         log_printf(0, "perform_final_verify:  FAILED\n");
     }
 
-    tbx_flush_log();
+    tbx_log_flush();
 
     free(buffer);
 }
@@ -484,7 +484,7 @@ op_generic_t *find_write_task(task_slot_t *tslot)
 
     write_index.curr++;
 
-    flip = my_tbx_random_int64(0, rwc.write_sigma-1);
+    flip = my_tbx_random_get_int64(0, rwc.write_sigma-1);
     n = -1;
     for (i=0; i< rwc.write_sigma; i++) {
         j = (flip + i) % rwc.write_sigma;  //** Used to map the slot to the span range
@@ -496,12 +496,12 @@ op_generic_t *find_write_task(task_slot_t *tslot)
     }
 
     log_printf(my_log_level, "find_write_task: span global=%d flip=%d i=%d base=%d spanindex=%d\n", n, flip, i, write_index.base_index, (n%rwc.write_sigma));
-    tbx_flush_log();
+    tbx_log_flush();
 
     write_index.span[n%rwc.write_sigma] = 1;
     tslot->global_index = n;
     log_printf(my_log_level, "find_write_task: span slot=%d curr=%d base=%d global=%d\n", n, write_index.curr, write_index.base_index, tslot->global_index);
-    tbx_flush_log();
+    tbx_log_flush();
 
     tslot->local_index = (tslot->global_index) % tile_size;
     tslot->type = 0;
@@ -516,11 +516,11 @@ op_generic_t *find_write_task(task_slot_t *tslot)
 
     n = total_scan_size - rwc.write_sigma;
     log_printf(my_log_level, "find_write_task: span_update max=%d base=%d\n", n, write_index.base_index);
-    tbx_flush_log();
+    tbx_log_flush();
     for (i=0; i<rwc.write_sigma; i++) {
         slot = write_index.base_index % rwc.write_sigma;
         log_printf(my_log_level, "find_write_task: span_update slot=%d i=%d base=%d span[slot]=%d\n", slot, i, write_index.base_index, write_index.span[slot]);
-        tbx_flush_log();
+        tbx_log_flush();
 
         if (write_index.span[slot] == 0) break;
         if ( write_index.base_index >= n) break;  //** Don't move the window beyond the end
@@ -543,18 +543,18 @@ op_generic_t *find_read_task(task_slot_t *tslot, int write_done)
 
     if (read_index.curr >= total_scan_size) return(NULL);  //** Nothing left to do
 
-    flip = my_tbx_random_int64(0, rwc.read_sigma-1);
+    flip = my_tbx_random_get_int64(0, rwc.read_sigma-1);
 
     n = -1;
     for (i=0; i< rwc.read_sigma; i++) {
         j = (flip + i) % rwc.read_sigma;  //** Used to map the slot to the span range
         slot = (read_index.base_index + j) % rwc.read_sigma;
         log_printf(my_log_level, "find_read_task: span i=%d j=%d flip=%d base=%d spanslot=%d span[slot]=%d\n", i, j, flip,  read_index.base_index, slot, read_index.span[slot]);
-        tbx_flush_log();
+        tbx_log_flush();
         if (read_index.span[slot] == 0) {
             slot =  read_index.base_index + j;
             log_printf(my_log_level, "find_read_task: slot=%d wc=%c\n", slot, wc_span[slot]);
-            tbx_flush_log();
+            tbx_log_flush();
 
             if (wc_span[slot] == '1') {
                 n = read_index.base_index + j;
@@ -564,7 +564,7 @@ op_generic_t *find_read_task(task_slot_t *tslot, int write_done)
     }
 
     log_printf(my_log_level, "find_read_task: span global=%d flip=%d base=%d spanindex=%d\n", n, flip,  read_index.base_index, (n%rwc.read_sigma));
-    tbx_flush_log();
+    tbx_log_flush();
 
     if ((n<0) && (write_done >= total_scan_size)) {
         log_printf(0, "find_read_task:  ERROR!! No viable taks found!! Printing wc_span table (READ base=%d curr=%d  ---- WRITE base=%d curr=%d\n",
@@ -587,7 +587,7 @@ op_generic_t *find_read_task(task_slot_t *tslot, int write_done)
     tslot->type = 1;
 
     log_printf(my_log_level, "find_read_task: span slot=%d curr=%d base=%d global=%d\n", n, read_index.curr, read_index.base_index, tslot->global_index);
-    tbx_flush_log();
+    tbx_log_flush();
 
     slot = tile_index[tslot->local_index];
     offset = ((tslot->global_index) / tile_size) * tile_bytes + base_tile[slot].offset;
@@ -597,16 +597,16 @@ op_generic_t *find_read_task(task_slot_t *tslot, int write_done)
 
     gop = segment_read(seg, da, NULL, 1, &(tslot->iov), &(tslot->tbuf), 0, rwc.timeout);
     log_printf(my_log_level, "find_read_task: global=%d off=" XOT " len=" XOT " gop=%p\n", tslot->global_index, offset, base_tile[slot].len, gop);
-    tbx_flush_log();
+    tbx_log_flush();
 
     gop_set_private(gop, (void *)tslot);
 
     //** Move up the read base index
     n = total_scan_size - rwc.read_sigma;
-//log_printf(my_log_level, "find_read_task: span_update max=%d base=%d\n", n, read_index.base_index); tbx_flush_log();
+//log_printf(my_log_level, "find_read_task: span_update max=%d base=%d\n", n, read_index.base_index); tbx_log_flush();
     for (i=0; i<rwc.read_sigma; i++) {
         slot = read_index.base_index % rwc.read_sigma;
-//log_printf(my_log_level, "find_read_task: span_update slot=%d i=%d base=%d span[slot]=%d\n", slot, i, read_index.base_index, read_index.span[slot]); tbx_flush_log();
+//log_printf(my_log_level, "find_read_task: span_update slot=%d i=%d base=%d span[slot]=%d\n", slot, i, read_index.base_index, read_index.span[slot]); tbx_log_flush();
 
         if (read_index.span[slot] == 0) break;
         if (read_index.base_index >= n) break;  //** Don't move the window beyond the end
@@ -670,20 +670,20 @@ void rw_test()
 
     //** Setup everything
     log_printf(0, "Generating tasks and random data\n");
-    tbx_flush_log();
+    tbx_log_flush();
     generate_task_list();
     make_test_indices();
     log_printf(0, "Completed task and data generation\n\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Truncate the file to back to the correct size if needed
     if (rwc.preallocate == 1) {
         log_printf(0, "Preallocating all space\n\n");
-        tbx_flush_log();
+        tbx_log_flush();
         j = gop_sync_exec(segment_truncate(seg, da, total_scan_bytes, 10));
         if (j != OP_STATE_SUCCESS) {
             printf("Error truncating the file!\n");
-            tbx_flush_log();
+            tbx_log_flush();
             fflush(stdout);
             abort();
         }
@@ -736,7 +736,7 @@ void rw_test()
             gop = find_write_task(slot);
         }
 
-        tbx_flush_log();
+        tbx_log_flush();
 
         if (gop != NULL) {
             log_printf(1, "rw_test: SUBMITTING i=%d gid=%d mode=%d global=%d off=" XOT " len=" XOT "\n", i, gop_id(gop), slot->type, slot->global_index, slot->iov.offset, slot->iov.len);
@@ -853,13 +853,13 @@ void rw_test()
 
     if (rwc.do_flush_check > 0) {
         log_printf(0, "============ Flushing data and doing a last verification =============\n");
-        tbx_flush_log();
+        tbx_log_flush();
         dtt = apr_time_now();
         gop_sync_exec(segment_flush(seg, da, 0, total_scan_bytes, 30));
         dtt = apr_time_now() - dtt;
         dsec = (1.0*dtt) / APR_USEC_PER_SEC;
         log_printf(0, "============ Flush completed (%lf s) Dropping pages as well =============\n", dsec);
-        tbx_flush_log();
+        tbx_log_flush();
         cache_drop_pages(seg, 0, total_scan_bytes+1);  //** Drop all the pages so they have to be reloaded on next test
         perform_final_verify();
 
@@ -871,7 +871,7 @@ void rw_test()
         printf("----------------------------------------------------------\n");
     }
 
-    tbx_free_stack(free_slots, 0);
+    tbx_stack_free(free_slots, 0);
 }
 
 //*************************************************************************
@@ -883,30 +883,30 @@ void rw_load_options(char *cfgname, char *group)
     tbx_inip_file_t *fd;
     char *str;
 
-    fd = tbx_inip_file_read(cfgname);
+    fd = tbx_inip_read_file(cfgname);
     if (fd == NULL) {
         printf("rw_load_config:  ERROR opening config file: %s\n", cfgname);
-        tbx_flush_log();
+        tbx_log_flush();
         fflush(stdout);
         abort();
     }
 
     //** Parse the global params
-    rwc.n_parallel = tbx_inip_integer_get(fd, group, "parallel", 1);
-    rwc.preallocate = tbx_inip_integer_get(fd, group, "preallocate", 0);
-    rwc.buffer_size = tbx_inip_integer_get(fd, group, "buffer_size", 10*1024*1024);
-    rwc.file_size = tbx_inip_integer_get(fd, group, "file_size", 10*1024*1024);
-    rwc.do_final_check = tbx_inip_integer_get(fd, group, "do_final_check", 1);
-    rwc.do_flush_check = tbx_inip_integer_get(fd, group, "do_flush_check", 1);
-    rwc.timeout = tbx_inip_integer_get(fd, group, "timeout", 10);
-    rwc.update_interval = tbx_inip_integer_get(fd, group, "update_interval", 1000);
-    rwc.filename = tbx_inip_string_get(fd, group, "file", "");
-    rwc.read_lag = tbx_inip_integer_get(fd, group, "read_lag", 10);
-    rwc.read_fraction = tbx_inip_double_get(fd, group, "read_fraction", 0.0);
-    rwc.seed = tbx_inip_integer_get(fd, group, "seed", 1);
+    rwc.n_parallel = tbx_inip_get_integer(fd, group, "parallel", 1);
+    rwc.preallocate = tbx_inip_get_integer(fd, group, "preallocate", 0);
+    rwc.buffer_size = tbx_inip_get_integer(fd, group, "buffer_size", 10*1024*1024);
+    rwc.file_size = tbx_inip_get_integer(fd, group, "file_size", 10*1024*1024);
+    rwc.do_final_check = tbx_inip_get_integer(fd, group, "do_final_check", 1);
+    rwc.do_flush_check = tbx_inip_get_integer(fd, group, "do_flush_check", 1);
+    rwc.timeout = tbx_inip_get_integer(fd, group, "timeout", 10);
+    rwc.update_interval = tbx_inip_get_integer(fd, group, "update_interval", 1000);
+    rwc.filename = tbx_inip_get_string(fd, group, "file", "");
+    rwc.read_lag = tbx_inip_get_integer(fd, group, "read_lag", 10);
+    rwc.read_fraction = tbx_inip_get_double(fd, group, "read_fraction", 0.0);
+    rwc.seed = tbx_inip_get_integer(fd, group, "seed", 1);
     my_random_seed(rwc.seed);
 
-    str = tbx_inip_string_get(fd, group, "mode", "linear");
+    str = tbx_inip_get_string(fd, group, "mode", "linear");
     if (strcasecmp(str, "linear") == 0) {
         rwc.mode = 0;
     } else if (strcasecmp(str, "random") == 0) {
@@ -914,21 +914,21 @@ void rw_load_options(char *cfgname, char *group)
     } else {
         printf("rw_load_options: ERROR loading mode. mode=%s\n", str);
         printf("rw_load_options: Should be either 'linear' or 'random'.\n");
-        tbx_flush_log();
+        tbx_log_flush();
         fflush(stdout);
         abort();
     }
     free(str);
 
-    rwc.min_size = 1024.0*tbx_inip_double_get(fd, group, "min_size", 1);
+    rwc.min_size = 1024.0*tbx_inip_get_double(fd, group, "min_size", 1);
     if (rwc.min_size == 0) rwc.min_size = 1;
-    rwc.max_size = 1024.0*tbx_inip_double_get(fd, group, "max_size", 10);
+    rwc.max_size = 1024.0*tbx_inip_get_double(fd, group, "max_size", 10);
     if (rwc.max_size == 0) rwc.max_size = 1;
     rwc.ln_min = log(rwc.min_size);
     rwc.ln_max = log(rwc.max_size);
 
-    rwc.read_sigma = tbx_inip_integer_get(fd, group, "read_sigma", 50);
-    rwc.write_sigma = tbx_inip_integer_get(fd, group, "write_sigma", 50);
+    rwc.read_sigma = tbx_inip_get_integer(fd, group, "read_sigma", 50);
+    rwc.write_sigma = tbx_inip_get_integer(fd, group, "write_sigma", 50);
 
     tbx_inip_destroy(fd);
 }
@@ -1022,7 +1022,7 @@ int main(int argc, char **argv)
 
     if (lio_gc->cfg_name == NULL) {
         printf("ex_rw_test:  Missing config file!\n");
-        tbx_flush_log();
+        tbx_log_flush();
         fflush(stdout);
         abort();
     }
@@ -1047,7 +1047,7 @@ int main(int argc, char **argv)
     seg = exnode_get_default(ex);
     if (seg == NULL) {
         printf("No default segment!  Aborting!\n");
-        tbx_flush_log();
+        tbx_log_flush();
         fflush(stdout);
         abort();
     }
@@ -1057,7 +1057,7 @@ int main(int argc, char **argv)
         err = gop_sync_exec(segment_truncate(seg, da, 0, 10));
         if (err != OP_STATE_SUCCESS) {
             printf("Error truncating the remote file!\n");
-            tbx_flush_log();
+            tbx_log_flush();
             fflush(stdout);
             abort();
         }
@@ -1098,7 +1098,7 @@ int main(int argc, char **argv)
     err = gop_sync_exec(segment_truncate(seg, da, 0, 10));
     if (err != OP_STATE_SUCCESS) {
         printf("Error truncating the file!\n");
-        tbx_flush_log();
+        tbx_log_flush();
         fflush(stdout);
         abort();
     }

--- a/src/lio/exnode.c
+++ b/src/lio/exnode.c
@@ -312,7 +312,7 @@ exnode_exchange_t *exnode_exchange_create(int type)
 
 ex_id_t exnode_exchange_get_default_view_id(exnode_exchange_t *exp)
 {
-    return(tbx_inip_integer_get(exp->text.fd, "view", "default", 0));
+    return(tbx_inip_get_integer(exp->text.fd, "view", "default", 0));
 }
 
 //*************************************************************************
@@ -326,7 +326,7 @@ exnode_exchange_t *exnode_exchange_text_parse(char *text)
     exp = exnode_exchange_create(EX_TEXT);
 
     exp->text.text = text;
-    exp->text.fd = tbx_inip_string_read(text);
+    exp->text.fd = tbx_inip_read_string(text);
 
     return(exp);
 }
@@ -414,8 +414,8 @@ int exnode_deserialize_text(exnode_t *ex, exnode_exchange_t *exp, service_manage
     //** Load the header
     g = tbx_inip_group_find(fd, exgrp);
     if (g != NULL) {
-        ex->header.name =  tbx_inip_string_get(fd, exgrp, "name", "");
-        ex->header.id = tbx_inip_integer_get(fd, exgrp, "id", 0);
+        ex->header.name =  tbx_inip_get_string(fd, exgrp, "name", "");
+        ex->header.id = tbx_inip_get_integer(fd, exgrp, "id", 0);
     }
 
     //** and the views
@@ -427,11 +427,11 @@ int exnode_deserialize_text(exnode_t *ex, exnode_exchange_t *exp, service_manage
 
     ele = tbx_inip_ele_first(g);
     while (ele != NULL) {
-        key = tbx_inip_ele_key_get(ele);
+        key = tbx_inip_ele_get_key(ele);
         if (strcmp(key, "segment") == 0) {
 
             //** Parse the segment line
-            value = tbx_inip_ele_value_get(ele);
+            value = tbx_inip_ele_get_value(ele);
             token = strdup(value);
             id = 0;
             sscanf(tbx_stk_string_token(token, ":", &bstate, &fin), XIDT, &id);
@@ -453,7 +453,7 @@ int exnode_deserialize_text(exnode_t *ex, exnode_exchange_t *exp, service_manage
     }
 
     //** Now get the default segment to use
-    id = tbx_inip_integer_get(fd, "view", "default", 0);
+    id = tbx_inip_get_integer(fd, "view", "default", 0);
     if (id == 0) {   //** No default so use the last one loaded
         ex->default_seg = seg;
     } else {

--- a/src/lio/exnode.c
+++ b/src/lio/exnode.c
@@ -326,7 +326,7 @@ exnode_exchange_t *exnode_exchange_text_parse(char *text)
     exp = exnode_exchange_create(EX_TEXT);
 
     exp->text.text = text;
-    exp->text.fd = tbx_inip_read_string(text);
+    exp->text.fd = tbx_inip_string_read(text);
 
     return(exp);
 }

--- a/src/lio/liblio_trace.c
+++ b/src/lio/liblio_trace.c
@@ -79,7 +79,7 @@ void lt_load_config(char *fname)
     char *str;
     int n;
 
-    fd = tbx_inip_read_file(fname);
+    fd = tbx_inip_file_read(fname);
 
     n = tbx_inip_get_integer(fd, LIBLIO_TRACE_SECTION, "log_level", tbx_log_level());
     tbx_set_log_level(n);

--- a/src/lio/liblio_trace.c
+++ b/src/lio/liblio_trace.c
@@ -79,21 +79,21 @@ void lt_load_config(char *fname)
     char *str;
     int n;
 
-    fd = tbx_inip_file_read(fname);
+    fd = tbx_inip_read_file(fname);
 
-    n = tbx_inip_integer_get(fd, LIBLIO_TRACE_SECTION, "log_level", tbx_log_level());
+    n = tbx_inip_get_integer(fd, LIBLIO_TRACE_SECTION, "log_level", tbx_log_level());
     tbx_set_log_level(n);
 
-    str = tbx_inip_string_get(fd, LIBLIO_TRACE_SECTION, "log_file", NULL);
+    str = tbx_inip_get_string(fd, LIBLIO_TRACE_SECTION, "log_file", NULL);
     if (str != NULL) open_log(str);
 
-    str = tbx_inip_string_get(fd, LIBLIO_TRACE_SECTION, "output", NULL);
+    str = tbx_inip_get_string(fd, LIBLIO_TRACE_SECTION, "output", NULL);
     if (str != NULL) ltc.trace_name = str;
 
-    str = tbx_inip_string_get(fd, LIBLIO_TRACE_SECTION, "header", NULL);
+    str = tbx_inip_get_string(fd, LIBLIO_TRACE_SECTION, "header", NULL);
     if (str != NULL) ltc.trace_header = str;
 
-    ltc.max_fd = tbx_inip_integer_get(fd, LIBLIO_TRACE_SECTION, "max_fd", ltc.max_fd);
+    ltc.max_fd = tbx_inip_get_integer(fd, LIBLIO_TRACE_SECTION, "max_fd", ltc.max_fd);
 
     ltc.logfd = STDERR_FILENO;
 

--- a/src/lio/lio_config.c
+++ b/src/lio/lio_config.c
@@ -847,7 +847,7 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     lio->cfg_name = strdup(fname);
     lio->section_name = strdup(section);
 
-    lio->ifd = tbx_inip_read_file(lio->cfg_name);
+    lio->ifd = tbx_inip_file_read(lio->cfg_name);
 
     _lio_load_plugins(lio, lio->ifd);  //** Load the plugins
 

--- a/src/lio/lio_config.c
+++ b/src/lio/lio_config.c
@@ -152,15 +152,15 @@ void _lio_load_plugins(lio_config_t *lio, tbx_inip_file_t *fd)
             ele = tbx_inip_ele_first(g);
             section = name = library = symbol = NULL;
             while (ele != NULL) {
-                key = tbx_inip_ele_key_get(ele);
+                key = tbx_inip_ele_get_key(ele);
                 if (strcmp(key, "section") == 0) {
-                    section = tbx_inip_ele_value_get(ele);
+                    section = tbx_inip_ele_get_value(ele);
                 } else if (strcmp(key, "name") == 0) {
-                    name = tbx_inip_ele_value_get(ele);
+                    name = tbx_inip_ele_get_value(ele);
                 } else if (strcmp(key, "library") == 0) {
-                    library = tbx_inip_ele_value_get(ele);
+                    library = tbx_inip_ele_get_value(ele);
                 } else if (strcmp(key, "symbol") == 0) {
-                    symbol = tbx_inip_ele_value_get(ele);
+                    symbol = tbx_inip_ele_get_value(ele);
                 }
 
                 ele = tbx_inip_ele_next(ele);
@@ -217,7 +217,7 @@ void _lio_destroy_plugins(lio_config_t *lio)
         free(library_key);
     }
 
-    tbx_free_stack(lio->plugin_stack, 0);
+    tbx_stack_free(lio->plugin_stack, 0);
 }
 
 
@@ -270,7 +270,7 @@ void lio_find_lfs_mounts()
         free(entry);
     }
 
-    tbx_free_stack(stack, 0);
+    tbx_stack_free(stack, 0);
 }
 
 //***************************************************************
@@ -626,7 +626,7 @@ void lc_object_remove_unused(int remove_all_unused)
 
     apr_thread_mutex_unlock(_lc_lock);
 
-    tbx_free_stack(stack, 0);
+    tbx_stack_free(stack, 0);
     tbx_list_destroy(user_lc);
 
     return;
@@ -668,9 +668,9 @@ blacklist_t *blacklist_load(tbx_inip_file_t *ifd, char *section)
     apr_thread_mutex_create(&(bl->lock), APR_THREAD_MUTEX_DEFAULT, bl->mpool);
     bl->table = apr_hash_make(bl->mpool);
 
-    bl->timeout = tbx_inip_integer_get(ifd, section, "timeout", apr_time_from_sec(120));
-    bl->min_bandwidth = tbx_inip_integer_get(ifd, section, "min_bandwidth", 5*1024*1024);  //** default ro 5MB
-    bl->min_io_time = tbx_inip_integer_get(ifd, section, "min_io_time", apr_time_from_sec(1));  //** default ro 5MB
+    bl->timeout = tbx_inip_get_integer(ifd, section, "timeout", apr_time_from_sec(120));
+    bl->min_bandwidth = tbx_inip_get_integer(ifd, section, "min_bandwidth", 5*1024*1024);  //** default ro 5MB
+    bl->min_io_time = tbx_inip_get_integer(ifd, section, "min_io_time", apr_time_from_sec(1));  //** default ro 5MB
 
     return(bl);
 }
@@ -847,18 +847,18 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     lio->cfg_name = strdup(fname);
     lio->section_name = strdup(section);
 
-    lio->ifd = tbx_inip_file_read(lio->cfg_name);
+    lio->ifd = tbx_inip_read_file(lio->cfg_name);
 
     _lio_load_plugins(lio, lio->ifd);  //** Load the plugins
 
-    lio->timeout = tbx_inip_integer_get(lio->ifd, section, "timeout", 120);
-    lio->max_attr = tbx_inip_integer_get(lio->ifd, section, "max_attr_size", 10*1024*1024);
-    lio->calc_adler32 = tbx_inip_integer_get(lio->ifd, section, "calc_adler32", 0);
-    lio->readahead = tbx_inip_integer_get(lio->ifd, section, "readahead", 0);
-    lio->readahead_trigger = lio->readahead * tbx_inip_double_get(lio->ifd, section, "readahead_trigger", 1.0);
+    lio->timeout = tbx_inip_get_integer(lio->ifd, section, "timeout", 120);
+    lio->max_attr = tbx_inip_get_integer(lio->ifd, section, "max_attr_size", 10*1024*1024);
+    lio->calc_adler32 = tbx_inip_get_integer(lio->ifd, section, "calc_adler32", 0);
+    lio->readahead = tbx_inip_get_integer(lio->ifd, section, "readahead", 0);
+    lio->readahead_trigger = lio->readahead * tbx_inip_get_double(lio->ifd, section, "readahead_trigger", 1.0);
 
     //** Check and see if we need to enable the blacklist
-    stype = tbx_inip_string_get(lio->ifd, section, "blacklist", NULL);
+    stype = tbx_inip_get_string(lio->ifd, section, "blacklist", NULL);
     if (stype != NULL) { //** Yup we need to parse and load those params
         lio->blacklist = blacklist_load(lio->ifd, stype);
         add_service(lio->ess, ESS_RUNNING, "blacklist", lio->blacklist);
@@ -867,11 +867,11 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
 
     //** Add the Jerase paranoid option
     tbx_type_malloc(val, int, 1);  //** NOTE: this is not freed on a destroy
-    *val = tbx_inip_integer_get(lio->ifd, section, "jerase_paranoid", 0);
+    *val = tbx_inip_get_integer(lio->ifd, section, "jerase_paranoid", 0);
     add_service(lio->ess, ESS_RUNNING, "jerase_paranoid", val);
 
-    cores = tbx_inip_integer_get(lio->ifd, section, "tpc_unlimited", 200);
-    max_recursion = tbx_inip_integer_get(lio->ifd, section, "tpc_max_recursion", 10);
+    cores = tbx_inip_get_integer(lio->ifd, section, "tpc_unlimited", 200);
+    max_recursion = tbx_inip_get_integer(lio->ifd, section, "tpc_max_recursion", 10);
     sprintf(buffer, "tpc:%d", cores);
     stype = buffer;
     lio->tpc_unlimited_section = strdup(stype);
@@ -893,7 +893,7 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     add_service(lio->ess, ESS_RUNNING, ESS_TPC_UNLIMITED, lio->tpc_unlimited);
 
 
-    cores = tbx_inip_integer_get(lio->ifd, section, "tpc_cache", 100);
+    cores = tbx_inip_get_integer(lio->ifd, section, "tpc_cache", 100);
     sprintf(buffer, "tpc-cache:%d", cores);
     stype = buffer;
     lio->tpc_cache_section = strdup(stype);
@@ -915,7 +915,7 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     add_service(lio->ess, ESS_RUNNING, ESS_TPC_CACHE, lio->tpc_cache);
 
 
-    stype = tbx_inip_string_get(lio->ifd, section, "mq", "mq_context");
+    stype = tbx_inip_get_string(lio->ifd, section, "mq", "mq_context");
     lio->mq_section = stype;
     lio->mqc = _lc_object_get(stype);
     if (lio->mqc == NULL) {  //** Need to load it
@@ -936,11 +936,11 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     mq_ongoing_t *on = mq_ongoing_create(lio->mqc, NULL, 1, ONGOING_CLIENT);
     add_service(lio->ess, ESS_RUNNING, ESS_ONGOING_CLIENT, on);
 
-    stype = tbx_inip_string_get(lio->ifd, section, "ds", DS_TYPE_IBP);
+    stype = tbx_inip_get_string(lio->ifd, section, "ds", DS_TYPE_IBP);
     lio->ds_section = stype;
     lio->ds = _lc_object_get(stype);
     if (lio->ds == NULL) {  //** Need to load it
-        ctype = tbx_inip_string_get(lio->ifd, stype, "type", DS_TYPE_IBP);
+        ctype = tbx_inip_get_string(lio->ifd, stype, "type", DS_TYPE_IBP);
         ds_create = lookup_service(lio->ess, DS_SM_AVAILABLE, ctype);
         lio->ds = (*ds_create)(lio->ess, lio->ifd, stype);
         if (lio->ds == NULL) {
@@ -960,11 +960,11 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     add_service(lio->ess, ESS_RUNNING, ESS_DS, lio->ds);  //** This is needed by the RS service
     add_service(lio->ess, ESS_RUNNING, ESS_DA, lio->da);  //** This is needed by the RS service
 
-    stype = tbx_inip_string_get(lio->ifd, section, "rs", RS_TYPE_SIMPLE);
+    stype = tbx_inip_get_string(lio->ifd, section, "rs", RS_TYPE_SIMPLE);
     lio->rs_section = stype;
     lio->rs = _lc_object_get(stype);
     if (lio->rs == NULL) {  //** Need to load it
-        ctype = tbx_inip_string_get(lio->ifd, stype, "type", RS_TYPE_SIMPLE);
+        ctype = tbx_inip_get_string(lio->ifd, stype, "type", RS_TYPE_SIMPLE);
         rs_create = lookup_service(lio->ess, RS_SM_AVAILABLE, ctype);
         lio->rs = (*rs_create)(lio->ess, lio->ifd, stype);
         if (lio->rs == NULL) {
@@ -979,11 +979,11 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     }
     add_service(lio->ess, ESS_RUNNING, ESS_RS, lio->rs);
 
-    stype = tbx_inip_string_get(lio->ifd, section, "os", "osfile");
+    stype = tbx_inip_get_string(lio->ifd, section, "os", "osfile");
     lio->os_section = stype;
     lio->os = _lc_object_get(stype);
     if (lio->os == NULL) {  //** Need to load it
-        ctype = tbx_inip_string_get(lio->ifd, stype, "type", OS_TYPE_FILE);
+        ctype = tbx_inip_get_string(lio->ifd, stype, "type", OS_TYPE_FILE);
         os_create = lookup_service(lio->ess, OS_AVAILABLE, ctype);
         lio->os = (*os_create)(lio->ess, lio->ifd, stype);
         if (lio->os == NULL) {
@@ -999,7 +999,7 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     add_service(lio->ess, ESS_RUNNING, ESS_OS, lio->os);
 
     cred_args[0] = lio->cfg_name;
-    cred_args[1] = (user == NULL) ? tbx_inip_string_get(lio->ifd, section, "user", "guest") : strdup(user);
+    cred_args[1] = (user == NULL) ? tbx_inip_get_string(lio->ifd, section, "user", "guest") : strdup(user);
     snprintf(buffer, sizeof(buffer), "tuple:%s@%s", cred_args[1], lio->section_name);
     stype = buffer;
     lio->creds_name = strdup(buffer);
@@ -1020,8 +1020,8 @@ lio_config_t *lio_create_nl(char *fname, char *section, char *user, char *exe_na
     _lc_object_get(buffer);
 
     if (_lio_cache == NULL) {
-        stype = tbx_inip_string_get(lio->ifd, section, "cache", CACHE_TYPE_AMP);
-        ctype = tbx_inip_string_get(lio->ifd, stype, "type", CACHE_TYPE_AMP);
+        stype = tbx_inip_get_string(lio->ifd, section, "cache", CACHE_TYPE_AMP);
+        ctype = tbx_inip_get_string(lio->ifd, stype, "type", CACHE_TYPE_AMP);
         cache_create = lookup_service(lio->ess, CACHE_LOAD_AVAILABLE, ctype);
         _lio_cache = (*cache_create)(lio->ess, lio->ifd, stype, lio->da, lio->timeout);
         if (_lio_cache == NULL) {

--- a/src/lio/lio_config.c
+++ b/src/lio/lio_config.c
@@ -261,7 +261,7 @@ void lio_find_lfs_mounts()
     if (text != NULL) free(text);  //** Getline() always returns something
 
     //** Convert it to a simple array
-    _lfs_mount_count = tbx_stack_size(stack);
+    _lfs_mount_count = tbx_stack_count(stack);
     tbx_type_malloc(lfs_mount, lfs_mount_t, _lfs_mount_count);
     for (i=0; i<_lfs_mount_count; i++) {
         entry = tbx_stack_pop(stack);

--- a/src/lio/lio_core.c
+++ b/src/lio/lio_core.c
@@ -821,7 +821,7 @@ op_status_t lioc_create_object_fn(void *arg, int id)
     v_size[6] = 1;
 
     log_printf(15, "NEW ino=%s exnode=%s\n", val[4], val[ex_key]);
-    tbx_flush_log();
+    tbx_log_flush();
 
     err = gop_sync_exec(os_set_multiple_attrs(op->lc->os, op->creds, fd, _lioc_create_keys, (void **)val, v_size, (op->type & OS_OBJECT_FILE) ? _n_lioc_file_keys : _n_lioc_dir_keys));
     if (err != OP_STATE_SUCCESS) {

--- a/src/lio/lio_core_io.c
+++ b/src/lio/lio_core_io.c
@@ -263,7 +263,7 @@ void lio_store_and_release_adler32(lio_config_t *lc, creds_t *creds, tbx_list_t 
     }
 
     tbx_list_destroy(write_table);
-    tbx_free_stack(stack, 1);
+    tbx_stack_free(stack, 1);
 
     //** Store the attribute
     aval = cksum;
@@ -548,7 +548,7 @@ op_status_t lio_myclose_fn(void *arg, int id)
     double dt;
 
     log_printf(1, "fname=%s modified=%d count=%d\n", fd->path, fd->fh->modified, fd->fh->ref_count);
-    tbx_flush_log();
+    tbx_log_flush();
 
     status = op_success_status;
 
@@ -579,7 +579,7 @@ op_status_t lio_myclose_fn(void *arg, int id)
     log_printf(1, "FLUSH fname=%s dt=%lf\n", fd->path, dt);
 
     log_printf(5, "starting update process fname=%s modified=%d\n", fd->path, fh->modified);
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Ok no one has the file opened so teardown the segment/exnode
     //** IF not modified just tear down and clean up
@@ -717,7 +717,7 @@ op_status_t lio_read_ex_fn(void *arg, int id)
     t1 = iov[0].len;
     t2 = iov[0].offset;
     log_printf(1, "fname=%s n_iov=%d iov[0].len=" XOT " iov[0].offset=" XOT "\n", fd->path, op->n_iov, t1, t2);
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (fd == NULL) {
         log_printf(0, "ERROR: Got a null file desriptor\n");
@@ -741,7 +741,7 @@ op_status_t lio_read_ex_fn(void *arg, int id)
     dt = apr_time_now() - now;
     dt /= APR_USEC_PER_SEC;
     log_printf(1, "END fname=%s seg=" XIDT " dt=%lf\n", fd->path, segment_id(fd->fh->seg), dt);
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (err != OP_STATE_SUCCESS) {
         log_printf(1, "ERROR with read! fname=%s\n", fd->path);
@@ -975,7 +975,7 @@ op_status_t lio_write_ex_fn(void *arg, int id)
     t1 = iov[0].len;
     t2 = iov[0].offset;
     log_printf(1, "START fname=%s n_iov=%d iov[0].len=" XOT " iov[0].offset=" XOT "\n", fd->path, op->n_iov, t1, t2);
-    tbx_flush_log();
+    tbx_log_flush();
     if (tbx_log_level() > 0) {
         for (i=0; i < op->n_iov; i++) {
             t2 = iov[i].offset+iov[i].len-1;
@@ -999,7 +999,7 @@ op_status_t lio_write_ex_fn(void *arg, int id)
     dt = apr_time_now() - now;
     dt /= APR_USEC_PER_SEC;
     log_printf(1, "END fname=%s seg=" XIDT " dt=%lf\n", fd->path, segment_id(fd->fh->seg), dt);
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (fd->fh->write_table != NULL) {
         tbx_tbuf_t tb;
@@ -1492,7 +1492,7 @@ op_status_t lio_cp_path_fn(void *arg, int id)
     op_status_t status;
 
     log_printf(15, "START src=%s dest=%s max_spawn=%d bufsize=" XOT "\n", cp->src_tuple.path, cp->dest_tuple.path, cp->max_spawn, cp->bufsize);
-    tbx_flush_log();
+    tbx_log_flush();
 
     it = unified_create_object_iter(cp->src_tuple, cp->path_regex, cp->obj_regex, cp->obj_types, cp->recurse_depth);
     if (it == NULL) {

--- a/src/lio/lio_core_os.c
+++ b/src/lio/lio_core_os.c
@@ -300,7 +300,7 @@ op_status_t lio_create_object_fn(void *arg, int id)
     v_size[6] = 1;
 
     log_printf(15, "NEW ino=%s exnode=%s\n", val[4], val[ex_key]);
-    tbx_flush_log();
+    tbx_log_flush();
 
     err = gop_sync_exec(os_set_multiple_attrs(op->lc->os, op->creds, fd, _lio_create_keys, (void **)val, v_size, (op->type & OS_OBJECT_FILE) ? _n_lio_file_keys : _n_lio_dir_keys));
     if (err != OP_STATE_SUCCESS) {
@@ -1173,7 +1173,7 @@ int lio_stat(lio_config_t *lc, creds_t *creds, char *fname, struct stat *stat, c
     int v_size[_lio_stat_key_size], i, err;
 
     log_printf(1, "fname=%s\n", fname);
-    tbx_flush_log();
+    tbx_log_flush();
 
     for (i=0; i<_lio_stat_key_size; i++) v_size[i] = -lc->max_attr;
     err = lio_get_multiple_attrs(lc, creds, fname, NULL, _lio_stat_keys, (void **)val, v_size, _lio_stat_key_size);
@@ -1184,7 +1184,7 @@ int lio_stat(lio_config_t *lc, creds_t *creds, char *fname, struct stat *stat, c
     _lio_parse_stat_vals(fname, stat, val, v_size, mount_prefix, readlink);
 
     log_printf(1, "END fname=%s err=%d\n", fname, err);
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(0);
 
@@ -1401,7 +1401,7 @@ op_status_t lio_fsck_object_fn(void *arg, int id)
     char *val[_n_fsck_keys];
     int v_size[_n_fsck_keys];
     log_printf(15, "fname=%s START\n", op->path);
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (op->ftype <= 0) { //** Bad Ftype so see if we can figure it out
         op->ftype = lio_exists(op->lc, op->creds, op->path);
@@ -1415,7 +1415,7 @@ op_status_t lio_fsck_object_fn(void *arg, int id)
 
     if (op->full == 0) {
         log_printf(15, "fname=%s getting attrs\n", op->path);
-        tbx_flush_log();
+        tbx_log_flush();
         for (i=0; i<_n_fsck_keys; i++) {
             val[i] = NULL;
             v_size[i] = -op->lc->max_attr;
@@ -1442,7 +1442,7 @@ op_generic_t *lio_fsck_object(lio_config_t *lc, creds_t *creds, char *fname, int
     lio_fsck_check_t *op;
 
     log_printf(15, "fname=%s START\n", fname);
-    tbx_flush_log();
+    tbx_log_flush();
 
     tbx_type_malloc_clear(op, lio_fsck_check_t, 1);
 

--- a/src/lio/lio_cp.c
+++ b/src/lio/lio_cp.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
         goto finished;
     } else if (n_paths == 1) {
         log_printf(15, "11111111\n");
-        tbx_flush_log();
+        tbx_log_flush();
         if (((dtype & OS_OBJECT_FILE) > 0) || (dtype == 0)) {  //** Single path and dest is an existing file or doesn't exist
             if (os_regex_is_fixed(flist[0].path_regex) == 0) {  //** Uh oh we have a wildcard with a single file dest
                 info_printf(lio_ifd, 0, "ERROR: Single wildcard path(%s) selected but the dest(%s) is a file or doesn't exist!\n", flist[0].src_tuple.path, dtuple.path);
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
         }
 
         log_printf(15, "2222222222222222 fixed=%d exp=%s dtype=%d\n", os_regex_is_fixed(flist[0].path_regex), flist[0].path_regex->regex_entry[0].expression, dtype);
-        tbx_flush_log();
+        tbx_log_flush();
 
         //**if it's a fixed src with a dir dest we skip and use the cp_fn routines
         if ((os_regex_is_fixed(flist[0].path_regex) == 1) && ((dtype == 0) || ((dtype & OS_OBJECT_FILE) > 0))) {
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
                 goto finished;
             }
             log_printf(15, "333333333333333333\n");
-            tbx_flush_log();
+            tbx_log_flush();
 
             goto finished;
         }

--- a/src/lio/lio_fuse_core.c
+++ b/src/lio/lio_fuse_core.c
@@ -359,7 +359,7 @@ int lfs_readdir(const char *dname, void *buf, fuse_fill_dir_t filler, off_t off,
     apr_time_t now;
     double dt;
     int off2 = off;
-    log_printf(1, "dname=%s off=%d stack_size=%d\n", dname, off2, tbx_stack_size(dit->stack));
+    log_printf(1, "dname=%s off=%d stack_size=%d\n", dname, off2, tbx_stack_count(dit->stack));
     tbx_log_flush();
     now = apr_time_now();
 
@@ -370,7 +370,7 @@ int lfs_readdir(const char *dname, void *buf, fuse_fill_dir_t filler, off_t off,
     off++;  //** This is the *next* slot to get where the stack top is off=1
 
     memset(&stbuf, 0, sizeof(stbuf));
-    n = tbx_stack_size(dit->stack);
+    n = tbx_stack_count(dit->stack);
     if (n>=off) { //** Rewind
         tbx_stack_move_to_bottom(dit->stack);  //** Go from the bottom up.
         for (i=n; i>off; i--) tbx_stack_move_up(dit->stack);

--- a/src/lio/lio_inspect.c
+++ b/src/lio/lio_inspect.c
@@ -224,7 +224,7 @@ void process_pool(pool_entry_t *pe, tbx_stack_t *parent_rid_stack)
     int cnt = 0;
     log_printf(0, "parent_rid_stack=%p pe->rids=%p\n", parent_rid_stack, pe->rids);
     while ((re = tbx_stack_pop(pe->rids)) != NULL) {
-        log_printf(0, "count=%d stack_size=%d\n", cnt, tbx_stack_size(pe->rids));
+        log_printf(0, "count=%d stack_size=%d\n", cnt, tbx_stack_count(pe->rids));
         cnt++;
         log_printf(5, "re->ri.rid->rid_key=%s re=%p\n", re->ri.rid->rid_key, re);
         tbx_stack_push(parent_rid_stack, re);

--- a/src/lio/lio_inspect.c
+++ b/src/lio/lio_inspect.c
@@ -427,11 +427,11 @@ apr_hash_t *load_pool_config(char *fname, apr_pool_t *mpool, tbx_stack_t *my_poo
     pool_list = (my_pool_list == NULL) ? tbx_stack_new() : my_pool_list;
 
     //** Load the pool config
-    pfd = tbx_inip_read_file(fname); assert(pfd != NULL);
+    pfd = tbx_inip_file_read(fname); assert(pfd != NULL);
 
     //** Do the same for RID config converting it to something useful
     rid_config = rs_get_rid_config(lio_gc->rs); assert(rid_config != NULL);
-    rfd = tbx_inip_read_string(rid_config); assert(rfd != NULL);
+    rfd = tbx_inip_string_read(rid_config); assert(rfd != NULL);
 
     //** Load the RID config into a usable table for converting to pools
     rid_table = prep_rid_table(rfd, mpool);
@@ -513,7 +513,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
 
     //** Process the RID config converting it to something useful
     rid_config = rs_get_rid_config(lio_gc->rs); assert(rid_config != NULL);
-    rfd = tbx_inip_read_string(rid_config); assert(rfd != NULL);
+    rfd = tbx_inip_string_read(rid_config); assert(rfd != NULL);
 
     //** Load the RID config into a usable table for converting to pools
     rid_table = prep_rid_table(rfd, mpool);
@@ -526,7 +526,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
                  "_unspecified\n", tstr);
 
         //** and load it
-        pfd = tbx_inip_read_string(pool_text); assert(pfd != NULL);
+        pfd = tbx_inip_string_read(pool_text); assert(pfd != NULL);
         load_pool(pool_list, "all", pfd, rfd, rid_table, tbx_inip_group_first(pfd), &unspecified);
         tbx_inip_destroy(pfd);
         add_wildcard(unspecified, rid_table, NULL, NULL);  //** This populates the unspecified wildcard
@@ -549,7 +549,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
                                  "%s=%s\n", value, tstr, key_rebalance, value);
 
                         //** and load it
-                        pfd = tbx_inip_read_string(pool_text); assert(pfd != NULL);
+                        pfd = tbx_inip_string_read(pool_text); assert(pfd != NULL);
                         pe = load_pool(pool_list, value, pfd, rfd, rid_table, tbx_inip_group_first(pfd), &unspecified);
                         tbx_inip_destroy(pfd);
 
@@ -753,7 +753,7 @@ op_status_t inspect_task(void *arg, int id)
     }
 
     //** Kind of kludgy to load the ex twice but this is more of a prototype fn
-    ifd = tbx_inip_read_string(w->exnode);
+    ifd = tbx_inip_string_read(w->exnode);
     dsegid = tbx_inip_get_string(ifd, "view", "default", NULL);
     tbx_inip_destroy(ifd);
     if (dsegid == NULL) {

--- a/src/lio/lio_inspect.c
+++ b/src/lio/lio_inspect.c
@@ -157,7 +157,7 @@ void process_pool(pool_entry_t *pe, tbx_stack_t *parent_rid_stack)
 
     //** Recursively handle all the groups
     tbx_stack_move_to_top(pe->groups);
-    while ((p = tbx_get_ele_data(pe->groups)) != NULL) {
+    while ((p = tbx_stack_get_current_data(pe->groups)) != NULL) {
         log_printf(5, " p->name=%s\n", p->name);
         process_pool(p, pe->rids);
         tbx_stack_move_down(pe->groups);
@@ -170,7 +170,7 @@ void process_pool(pool_entry_t *pe, tbx_stack_t *parent_rid_stack)
         //** Need to get the total size to calculate the fraction taget
         total_used = total_bytes = 0;
         tbx_stack_move_to_top(pe->rids);
-        while ((re = tbx_get_ele_data(pe->rids)) != NULL) {
+        while ((re = tbx_stack_get_current_data(pe->rids)) != NULL) {
             total_used += re->used;
             total_bytes += re->total;
             log_printf(5, "AUTO RID=%s used=" XOT " total=" XOT "\n", re->ri.rid->rid_key, re->used, re->total);
@@ -182,7 +182,7 @@ void process_pool(pool_entry_t *pe, tbx_stack_t *parent_rid_stack)
         //** Make the tweaks
         dsum = 0;
         tbx_stack_move_to_top(pe->rids);
-        while ((re = tbx_get_ele_data(pe->rids)) != NULL) {
+        while ((re = tbx_stack_get_current_data(pe->rids)) != NULL) {
             re->ri.rid->delta = avg * re->total - re->used;
             re->ri.rid->tolerance = 0.05*re->total;
             re->ri.rid->tolerance = (pe->tolerance_mode == DELTA_MODE_ABS) ? fabs(pe->tolerance) : percent * re->total;
@@ -201,7 +201,7 @@ void process_pool(pool_entry_t *pe, tbx_stack_t *parent_rid_stack)
     case (DELTA_MODE_ABS) :
         //** Make the tweaks
         tbx_stack_move_to_top(pe->rids);
-        while ((re = tbx_get_ele_data(pe->rids)) != NULL) {
+        while ((re = tbx_stack_get_current_data(pe->rids)) != NULL) {
             re->ri.rid->delta = (pe->delta_mode == DELTA_MODE_PERCENT) ? pe->delta/100.0 * re->total : pe->delta;
             re->ri.rid->tolerance = (pe->tolerance_mode == DELTA_MODE_PERCENT) ? fabs(pe->tolerance)/100.0 * re->total : fabs(pe->tolerance);
             d1 = re->ri.rid->delta;
@@ -259,8 +259,8 @@ apr_hash_t *prep_rid_table(tbx_inip_file_t *fd, apr_pool_t *mpool)
             //** Now cycle through the attributes
             ele = tbx_inip_ele_first(ig);
             while (ele != NULL) {
-                key = tbx_inip_ele_key_get(ele);
-                value = tbx_inip_ele_value_get(ele);
+                key = tbx_inip_ele_get_key(ele);
+                value = tbx_inip_ele_get_value(ele);
                 if (strcmp(key, "rid_key") == 0) {  //** This is the RID so store it separate
                     re->ri.rid->rid_key = strdup(value);
                 } else if (strcmp(key, "ds_key") == 0) {  //** This is the RID so store it separate
@@ -307,8 +307,8 @@ void add_wildcard(pool_entry_t *p, apr_hash_t *rid_table, char *mkey, char *mval
         match = 0;
         if (mkey != NULL) {
             for (ele=tbx_inip_ele_first(re->ig); ele != NULL; ele = tbx_inip_ele_next(ele)) {
-                key = tbx_inip_ele_key_get(ele);
-                value = tbx_inip_ele_value_get(ele);
+                key = tbx_inip_ele_get_key(ele);
+                value = tbx_inip_ele_get_value(ele);
 
                 if ((strcmp(key, mkey) == 0) && (strcmp(value, mvalue) == 0)) {
                     match = 1;
@@ -349,8 +349,8 @@ pool_entry_t *load_pool(tbx_stack_t *pools, char *name, tbx_inip_file_t *pfd, tb
     //** Now cycle through the attributes
     ele = tbx_inip_ele_first(pg);
     while (ele != NULL) {
-        key = tbx_inip_ele_key_get(ele);
-        value = tbx_inip_ele_value_get(ele);
+        key = tbx_inip_ele_get_key(ele);
+        value = tbx_inip_ele_get_value(ele);
         if (strcmp(key, "_delta") == 0) {  //** Delta value
             if (strcmp(value, "auto") == 0) {
                 p->delta_mode = DELTA_MODE_AUTO;
@@ -427,11 +427,11 @@ apr_hash_t *load_pool_config(char *fname, apr_pool_t *mpool, tbx_stack_t *my_poo
     pool_list = (my_pool_list == NULL) ? tbx_stack_new() : my_pool_list;
 
     //** Load the pool config
-    pfd = tbx_inip_file_read(fname); assert(pfd != NULL);
+    pfd = tbx_inip_read_file(fname); assert(pfd != NULL);
 
     //** Do the same for RID config converting it to something useful
     rid_config = rs_get_rid_config(lio_gc->rs); assert(rid_config != NULL);
-    rfd = tbx_inip_string_read(rid_config); assert(rfd != NULL);
+    rfd = tbx_inip_read_string(rid_config); assert(rfd != NULL);
 
     //** Load the RID config into a usable table for converting to pools
     rid_table = prep_rid_table(rfd, mpool);
@@ -455,7 +455,7 @@ apr_hash_t *load_pool_config(char *fname, apr_pool_t *mpool, tbx_stack_t *my_poo
 
     //** Now make the final pass since the "unspecified" has been resolved.
     tbx_stack_move_to_top(pool_list);
-    while ((pe = tbx_get_ele_data(pool_list)) != NULL) {
+    while ((pe = tbx_stack_get_current_data(pool_list)) != NULL) {
         process_pool(pe, NULL);
 
         pe->pick_from = apr_hash_make(mpool);
@@ -470,7 +470,7 @@ apr_hash_t *load_pool_config(char *fname, apr_pool_t *mpool, tbx_stack_t *my_poo
         tbx_stack_move_down(pool_list);
     }
 
-    if (my_pool_list == NULL) tbx_free_stack(pool_list, 1);
+    if (my_pool_list == NULL) tbx_stack_free(pool_list, 1);
 
     free(rid_config);
     tbx_inip_destroy(rfd);
@@ -513,7 +513,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
 
     //** Process the RID config converting it to something useful
     rid_config = rs_get_rid_config(lio_gc->rs); assert(rid_config != NULL);
-    rfd = tbx_inip_string_read(rid_config); assert(rfd != NULL);
+    rfd = tbx_inip_read_string(rid_config); assert(rfd != NULL);
 
     //** Load the RID config into a usable table for converting to pools
     rid_table = prep_rid_table(rfd, mpool);
@@ -526,7 +526,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
                  "_unspecified\n", tstr);
 
         //** and load it
-        pfd = tbx_inip_string_read(pool_text); assert(pfd != NULL);
+        pfd = tbx_inip_read_string(pool_text); assert(pfd != NULL);
         load_pool(pool_list, "all", pfd, rfd, rid_table, tbx_inip_group_first(pfd), &unspecified);
         tbx_inip_destroy(pfd);
         add_wildcard(unspecified, rid_table, NULL, NULL);  //** This populates the unspecified wildcard
@@ -537,7 +537,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
             key = tbx_inip_group_get(ig);
             log_printf(5, "key=%s\n", key);
             if (strcmp("rid", key) == 0) {  //** Found a RID so check it for the key
-                value = tbx_inip_key_find(ig, key_rebalance);  //** Get the value
+                value = tbx_inip_find_key(ig, key_rebalance);  //** Get the value
                 log_printf(5, "%s=%s\n", key_rebalance, value);
                 if (value != NULL) { //** If it exists
                     pe = tbx_list_search(master, value); //** Check if we already have a pool with the value
@@ -549,7 +549,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
                                  "%s=%s\n", value, tstr, key_rebalance, value);
 
                         //** and load it
-                        pfd = tbx_inip_string_read(pool_text); assert(pfd != NULL);
+                        pfd = tbx_inip_read_string(pool_text); assert(pfd != NULL);
                         pe = load_pool(pool_list, value, pfd, rfd, rid_table, tbx_inip_group_first(pfd), &unspecified);
                         tbx_inip_destroy(pfd);
 
@@ -567,7 +567,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
 
     //** Now make the final pass since the "unspecified" has been resolved.
     tbx_stack_move_to_top(pool_list);
-    while ((pe = tbx_get_ele_data(pool_list)) != NULL) {
+    while ((pe = tbx_stack_get_current_data(pool_list)) != NULL) {
         process_pool(pe, NULL);
 
         pe->pick_from = apr_hash_make(mpool);
@@ -582,7 +582,7 @@ apr_hash_t *rebalance_pool(apr_pool_t *mpool, tbx_stack_t *my_pool_list, char *k
         tbx_stack_move_down(pool_list);
     }
 
-    if (my_pool_list == NULL) tbx_free_stack(pool_list, 1);
+    if (my_pool_list == NULL) tbx_stack_free(pool_list, 1);
 
     free(rid_config);
     tbx_inip_destroy(rfd);
@@ -612,7 +612,7 @@ void dump_pools(tbx_log_fd_t *ifd, tbx_stack_t *pools, int scale)
     tbx_stack_move_to_top(pools);
     tneg = tpos = 0;
     total_ntodo = total_ptodo = total_todo = total_finished = 0;
-    while ((pe = tbx_get_ele_data(pools)) != NULL) {
+    while ((pe = tbx_stack_get_current_data(pools)) != NULL) {
 
         //** Make the sorted list by DS-key
         master = tbx_list_create(0, &tbx_list_string_compare, tbx_list_string_dup, tbx_list_simple_free, tbx_list_no_data_free);
@@ -686,7 +686,7 @@ void check_pools(tbx_stack_t *pools, apr_thread_mutex_t *lock, int todo_mode, in
     if (lock) apr_thread_mutex_lock(lock);
     tbx_stack_move_to_top(pools);
     *finished = *todo = ntodo = ptodo = 0;
-    while ((pe = tbx_get_ele_data(pools)) != NULL) {
+    while ((pe = tbx_stack_get_current_data(pools)) != NULL) {
         for (hi = apr_hash_first(NULL, pe->pick_from); hi != NULL; hi = apr_hash_next(hi)) {
             apr_hash_this(hi, NULL, NULL, (void **)&rid);
             if (rid->state == 0) {
@@ -753,8 +753,8 @@ op_status_t inspect_task(void *arg, int id)
     }
 
     //** Kind of kludgy to load the ex twice but this is more of a prototype fn
-    ifd = tbx_inip_string_read(w->exnode);
-    dsegid = tbx_inip_string_get(ifd, "view", "default", NULL);
+    ifd = tbx_inip_read_string(w->exnode);
+    dsegid = tbx_inip_get_string(ifd, "view", "default", NULL);
     tbx_inip_destroy(ifd);
     if (dsegid == NULL) {
         info_printf(lio_ifd, 0, "ERROR  Failed with file %s (ftype=%d). No default segment!\n", w->fname, w->ftype);
@@ -765,10 +765,10 @@ op_status_t inspect_task(void *arg, int id)
 
     apr_thread_mutex_lock(lock);
     log_printf(15, "checking fname=%s segid=%s\n", w->fname, dsegid);
-    tbx_flush_log();
+    tbx_log_flush();
     ptr = tbx_list_search(seg_index, dsegid);
     log_printf(15, "checking fname=%s segid=%s got=%s\n", w->fname, dsegid, ptr);
-    tbx_flush_log();
+    tbx_log_flush();
     if (ptr != NULL) {
         apr_thread_mutex_unlock(lock);
         info_printf(lio_ifd, 0, "Skipping file %s (ftype=%d). Already loaded/processed.\n", w->fname, w->ftype);
@@ -821,9 +821,9 @@ op_status_t inspect_task(void *arg, int id)
 
     log_printf(15, "fname=%s inspect_gid=%d whattodo=%d bufsize=" XOT "\n", w->fname, gop_id(gop), whattodo, bufsize);
 
-    tbx_flush_log();
+    tbx_log_flush();
     gop_waitall(gop);
-    tbx_flush_log();
+    tbx_log_flush();
     status = gop_get_status(gop);
     log_printf(15, "fname=%s inspect_gid=%d status=%d %d\n", w->fname, gop_id(gop), status.op_status, status.error_code);
 

--- a/src/lio/lio_mv.c
+++ b/src/lio/lio_mv.c
@@ -52,7 +52,7 @@ op_status_t mv_fn(void *arg, int id)
     op_status_t status;
 
     log_printf(15, "START src=%s dest=%s\n", mv->src_tuple.path, mv->dest_tuple.path);
-    tbx_flush_log();
+    tbx_log_flush();
 
     status = op_success_status;
 
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
         goto finished;
     } else if (n_paths == 1) {
         log_printf(15, "11111111\n");
-        tbx_flush_log();
+        tbx_log_flush();
         if (((dtype & OS_OBJECT_FILE) > 0) || (dtype == 0)) {  //** Single path and dest is an existing file or doesn't exist
             if (os_regex_is_fixed(flist[0].regex) == 0) {  //** Uh oh we have a wildcard with a single file dest
                 info_printf(lio_ifd, 0, "ERROR: Single wildcard path(%s) selected but the dest(%s) is a file or doesn't exist!\n", flist[0].src_tuple.path, dtuple.path);
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
         }
 
         log_printf(15, "2222222222222222 fixed=%d exp=%s\n", os_regex_is_fixed(flist[0].regex), flist[0].regex->regex_entry[0].expression);
-        tbx_flush_log();
+        tbx_log_flush();
 
         //**if it's a fixed src with a dir dest we skip and use the mv_fn routines
         if ((os_regex_is_fixed(flist[0].regex) == 1) && ((dtype == 0) || ((dtype & OS_OBJECT_FILE) > 0))) {
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
             fname = NULL;
             if ((dtype & OS_OBJECT_FILE) > 0) { //** Existing file so rename it for backup
                 tbx_type_malloc(fname, char, strlen(dtuple.path) + 40);
-                tbx_random_bytes_get(&ui, sizeof(ui));  //** MAke the random name
+                tbx_random_get_bytes(&ui, sizeof(ui));  //** MAke the random name
                 sprintf(fname, "%s.mv.%ud", dtuple.path, ui);
                 err = gop_sync_exec(gop_lio_move_object(dtuple.lc, dtuple.creds, flist[0].src_tuple.path, fname));
                 if (err != OP_STATE_SUCCESS) {
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
             }
 
             log_printf(15, "333333333333333333\n");
-            tbx_flush_log();
+            tbx_log_flush();
 
             //** Now do the simple mv
             err = gop_sync_exec(gop_lio_move_object(dtuple.lc, dtuple.creds, flist[0].src_tuple.path, dtuple.path));
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
             }
 
             log_printf(15, "4444444444444444444\n");
-            tbx_flush_log();
+            tbx_log_flush();
 
             //** Clean up by removing the original dest if needed
             if (fname != NULL) {
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
             }
 
             log_printf(15, "55555555555555555\n");
-            tbx_flush_log();
+            tbx_log_flush();
 
             goto finished;
         }

--- a/src/lio/lio_rs.c
+++ b/src/lio/lio_rs.c
@@ -70,7 +70,7 @@ void print_rid_summary(char *config, int base)
     table = tbx_list_create(0, &tbx_list_string_compare, NULL, NULL, free);
 
     //** Open the file
-    kf = tbx_inip_read_string(config); assert(kf);
+    kf = tbx_inip_string_read(config); assert(kf);
 
     //** And load it
     ig = tbx_inip_group_first(kf);

--- a/src/lio/lio_rs.c
+++ b/src/lio/lio_rs.c
@@ -70,7 +70,7 @@ void print_rid_summary(char *config, int base)
     table = tbx_list_create(0, &tbx_list_string_compare, NULL, NULL, free);
 
     //** Open the file
-    kf = tbx_inip_string_read(config); assert(kf);
+    kf = tbx_inip_read_string(config); assert(kf);
 
     //** And load it
     ig = tbx_inip_group_first(kf);
@@ -82,8 +82,8 @@ void print_rid_summary(char *config, int base)
             //** Now cycle through the attributes
             ele = tbx_inip_ele_first(ig);
             while (ele != NULL) {
-                key = tbx_inip_ele_key_get(ele);
-                value = tbx_inip_ele_value_get(ele);
+                key = tbx_inip_ele_get_key(ele);
+                value = tbx_inip_ele_get_value(ele);
                 if (strcmp(key, "rid_key") == 0) {  //** This is the RID so store it separate
                     rsum->rid = value;
                 } else if (strcmp(key, "ds_key") == 0) {  //** Data service key

--- a/src/lio/lio_warm.c
+++ b/src/lio/lio_warm.c
@@ -66,7 +66,7 @@ void parse_tag_file(char *fname)
     tbx_inip_element_t *ele;
     char *key, *value, *v;
 
-    fd = tbx_inip_read_file(fname);
+    fd = tbx_inip_file_read(fname);
     if (fd == NULL) return;
 
     apr_pool_create(&tagged_pool, NULL);
@@ -117,7 +117,7 @@ op_status_t gen_warm_task(void *arg, int id)
     opque_t *q;
 
     log_printf(15, "warming fname=%s, dt=%d\n", w->fname, dt);
-    fd = tbx_inip_read_string(w->exnode);
+    fd = tbx_inip_string_read(w->exnode);
     tbx_inip_group_t *g;
 
     q = new_opque();
@@ -438,7 +438,7 @@ int main(int argc, char **argv)
 
     //** Get the RID config which is used in the summary
     config = rs_get_rid_config(lio_gc->rs);
-    ifd = tbx_inip_read_string(config); assert(ifd);
+    ifd = tbx_inip_string_read(config); assert(ifd);
 
     //** Convert it for easier lookup
     ig = tbx_inip_group_first(ifd);

--- a/src/lio/log_test.c
+++ b/src/lio/log_test.c
@@ -98,7 +98,7 @@ int compare_buffers_print(char *b1, char *b2, int len, ex_off_t offset)
 //i=(b1[last] == b2[last]) ? 0 : 1;
 //log_printf(0, "last compare=%d lst=%d\n", i, last);
 
-    tbx_flush_log();
+    tbx_log_flush();
     return(err);
 }
 

--- a/src/lio/os_remote_client.c
+++ b/src/lio/os_remote_client.c
@@ -354,7 +354,7 @@ op_generic_t *osrc_remove_regex_object(object_service_fn_t *os, creds_t *creds, 
     op->obj_types = obj_types;
     op->recurse_depth = recurse_depth;
     op->my_id = 0;
-    tbx_random_bytes_get(&(op->my_id), sizeof(op->my_id));
+    tbx_random_get_bytes(&(op->my_id), sizeof(op->my_id));
 
     gop = new_thread_pool_op(osrc->tpc, NULL, osrc_remove_regex_object_func, (void *)op, free, 1);
     return(gop);
@@ -607,7 +607,7 @@ op_generic_t *osrc_regex_object_set_multiple_attrs(object_service_fn_t *os, cred
     op->v_size= v_size;
     op->n_attrs = n_attrs;
     op->my_id = 0;
-    tbx_random_bytes_get(&(op->my_id), sizeof(op->my_id));
+    tbx_random_get_bytes(&(op->my_id), sizeof(op->my_id));
 
     gop = new_thread_pool_op(osrc->tpc, NULL, osrc_regex_object_set_multiple_attrs_func, (void *)op, free, 1);
     gop_set_private(gop, op);
@@ -2475,7 +2475,7 @@ object_service_fn_t *object_service_remote_client_create(service_manager_t *ess,
     tbx_type_malloc_clear(osrc, osrc_priv_t, 1);
     os->priv = (void *)osrc;
 
-    str = tbx_inip_string_get(fd, section, "os_temp", NULL);
+    str = tbx_inip_get_string(fd, section, "os_temp", NULL);
     if (str != NULL) {  //** Running in test/temp
         log_printf(0, "NOTE: Running in debug mode by loading Remote server locally!\n");
         osrc->os_remote = object_service_remote_server_create(ess, fd, str);
@@ -2483,30 +2483,30 @@ object_service_fn_t *object_service_remote_client_create(service_manager_t *ess,
         osrc->os_temp = ((osrs_priv_t *)(osrc->os_remote->priv))->os_child;
         free(str);
     } else {
-        asection = tbx_inip_string_get(fd, section, "authn", NULL);
-        atype = (asection == NULL) ? strdup(AUTHN_TYPE_FAKE) : tbx_inip_string_get(fd, asection, "type", AUTHN_TYPE_FAKE);
+        asection = tbx_inip_get_string(fd, section, "authn", NULL);
+        atype = (asection == NULL) ? strdup(AUTHN_TYPE_FAKE) : tbx_inip_get_string(fd, asection, "type", AUTHN_TYPE_FAKE);
         authn_create = lookup_service(ess, AUTHN_AVAILABLE, atype);
         osrc->authn = (*authn_create)(ess, fd, asection);
         free(atype);
         free(asection);
     }
 
-    osrc->timeout = tbx_inip_integer_get(fd, section, "timeout", 60);
-    osrc->heartbeat = tbx_inip_integer_get(fd, section, "heartbeat", 600);
-    osrc->remote_host_string = tbx_inip_string_get(fd, section, "remote_address", NULL);
+    osrc->timeout = tbx_inip_get_integer(fd, section, "timeout", 60);
+    osrc->heartbeat = tbx_inip_get_integer(fd, section, "heartbeat", 600);
+    osrc->remote_host_string = tbx_inip_get_string(fd, section, "remote_address", NULL);
     osrc->remote_host = mq_string_to_address(osrc->remote_host_string);
 
-    osrc->max_stream = tbx_inip_integer_get(fd, section, "max_stream", 1024*1024);
-    osrc->stream_timeout = tbx_inip_integer_get(fd, section, "stream_timeout", 65);
-    osrc->spin_interval = tbx_inip_integer_get(fd, section, "spin_interval", 1);
-    osrc->spin_fail = tbx_inip_integer_get(fd, section, "spin_fail", 4);
+    osrc->max_stream = tbx_inip_get_integer(fd, section, "max_stream", 1024*1024);
+    osrc->stream_timeout = tbx_inip_get_integer(fd, section, "stream_timeout", 65);
+    osrc->spin_interval = tbx_inip_get_integer(fd, section, "spin_interval", 1);
+    osrc->spin_fail = tbx_inip_get_integer(fd, section, "spin_fail", 4);
 
     apr_pool_create(&osrc->mpool, NULL);
     apr_thread_mutex_create(&(osrc->lock), APR_THREAD_MUTEX_DEFAULT, osrc->mpool);
     apr_thread_cond_create(&(osrc->cond), osrc->mpool);
     apr_gethostname(hostname, sizeof(hostname), osrc->mpool);
     n = 0;
-    tbx_random_bytes_get(&n, sizeof(n));
+    tbx_random_get_bytes(&n, sizeof(n));
     snprintf(buffer, sizeof(buffer), "%d:%s:%s:%u", osrc->heartbeat, hostname, _lio_exe_name, n);
     osrc->host_id = strdup(buffer);
     osrc->host_id_len = strlen(osrc->host_id)+1;

--- a/src/lio/os_remote_server.c
+++ b/src/lio/os_remote_server.c
@@ -139,7 +139,7 @@ void osrs_update_active_table(object_service_fn_t *os, mq_frame_t *hid)
     ele = apr_hash_get(osrs->active_table, host_id, id_len);
     if (ele == NULL) { //** 1st time so need to add it
         //** Check if we need to clean things up
-        if (tbx_stack_size(osrs->active_lru) >= osrs->max_active) {
+        if (tbx_stack_count(osrs->active_lru) >= osrs->max_active) {
             tbx_stack_move_to_bottom(osrs->active_lru);
             a = (osrs_active_t *)tbx_stack_get_current_data(osrs->active_lru);
             apr_hash_set(osrs->active_table, a->host_id, a->host_id_len, NULL);

--- a/src/lio/os_remote_server.c
+++ b/src/lio/os_remote_server.c
@@ -87,13 +87,13 @@ void osrs_print_active_table(object_service_fn_t *os, FILE *fd)
     fprintf(fd, "#timestamp: %s\n", sdate);
     fprintf(fd, "#host|start_time|last_time|count\n");
     tbx_stack_move_to_top(osrs->active_lru);
-    a = tbx_get_ele_data(osrs->active_lru);
+    a = tbx_stack_get_current_data(osrs->active_lru);
     while (a != NULL) {
         apr_ctime(sdate, a->start);
         apr_ctime(ldate, a->last);
         fprintf(fd, "%s|%s|%s|"XOT "\n", a->host_id, sdate, ldate, a->count);
         tbx_stack_move_down(osrs->active_lru);
-        a = tbx_get_ele_data(osrs->active_lru);
+        a = tbx_stack_get_current_data(osrs->active_lru);
     }
     apr_thread_mutex_unlock(osrs->lock);
 }
@@ -141,11 +141,11 @@ void osrs_update_active_table(object_service_fn_t *os, mq_frame_t *hid)
         //** Check if we need to clean things up
         if (tbx_stack_size(osrs->active_lru) >= osrs->max_active) {
             tbx_stack_move_to_bottom(osrs->active_lru);
-            a = (osrs_active_t *)tbx_get_ele_data(osrs->active_lru);
+            a = (osrs_active_t *)tbx_stack_get_current_data(osrs->active_lru);
             apr_hash_set(osrs->active_table, a->host_id, a->host_id_len, NULL);
             if (a->host_id) free(a->host_id);
             free(a);
-            tbx_delete_current(osrs->active_lru, 1, 0);
+            tbx_stack_delete_current(osrs->active_lru, 1, 0);
         }
 
         //** Now make the new entry
@@ -159,19 +159,19 @@ void osrs_update_active_table(object_service_fn_t *os, mq_frame_t *hid)
 
         //** add it
         tbx_stack_push(osrs->active_lru, a);
-        ele = tbx_get_ptr(osrs->active_lru);
+        ele = tbx_stack_get_current_ptr(osrs->active_lru);
         apr_hash_set(osrs->active_table, a->host_id, a->host_id_len, ele);
     }
 
     //** Get the handle
-    a = (osrs_active_t *)tbx_get_stack_ele_data(ele);
+    a = (osrs_active_t *)tbx_stack_ele_get_data(ele);
     a->last = apr_time_now();  //** Update it
     a->count++;
 
     //** and move it to the front
     tbx_stack_move_to_ptr(osrs->active_lru, ele);
     tbx_stack_unlink_current(osrs->active_lru, 1);
-    tbx_push_link(osrs->active_lru, ele);
+    tbx_stack_link_push(osrs->active_lru, ele);
 
     apr_thread_mutex_unlock(osrs->lock);
 }
@@ -3034,14 +3034,14 @@ void os_remote_server_destroy(object_service_fn_t *os)
 
     //** Cleanup the activity log
     tbx_stack_move_to_top(osrs->active_lru);
-    a = tbx_get_ele_data(osrs->active_lru);
+    a = tbx_stack_get_current_data(osrs->active_lru);
     while (a != NULL) {
         if (a->host_id) free(a->host_id);
         free(a);
         tbx_stack_move_down(osrs->active_lru);
-        a = tbx_get_ele_data(osrs->active_lru);
+        a = tbx_stack_get_current_data(osrs->active_lru);
     }
-    tbx_free_stack(osrs->active_lru, 0);
+    tbx_stack_free(osrs->active_lru, 0);
     //** The active_table hash gets destroyed when the pool is destroyed.
 
     //** Shutdown the child OS
@@ -3093,34 +3093,34 @@ object_service_fn_t *object_service_remote_server_create(service_manager_t *ess,
     assert(osrs->spin != NULL);
 
     //** Get the host name we bind to
-    osrs->hostname= tbx_inip_string_get(fd, section, "address", NULL);
+    osrs->hostname= tbx_inip_get_string(fd, section, "address", NULL);
 
     //** Get the activity log file
-    osrs->fname_activity = tbx_inip_string_get(fd, section, "log_activity", NULL);
+    osrs->fname_activity = tbx_inip_get_string(fd, section, "log_activity", NULL);
     log_printf(5, "section=%s log_activity=%s\n", section, osrs->fname_activity);
 
     //** Ongoing check interval
-    osrs->ongoing_interval = tbx_inip_integer_get(fd, section, "ongoing_interval", 300);
+    osrs->ongoing_interval = tbx_inip_get_integer(fd, section, "ongoing_interval", 300);
 
     //** Max Stream size
-    osrs->max_stream = tbx_inip_integer_get(fd, section, "max_stream", 1024*1024);
+    osrs->max_stream = tbx_inip_get_integer(fd, section, "max_stream", 1024*1024);
 
     //** Start the child OS.
-    stype = tbx_inip_string_get(fd, section, "os_local", NULL);
+    stype = tbx_inip_get_string(fd, section, "os_local", NULL);
     if (stype == NULL) {  //** Oops missing child OS
         log_printf(0, "ERROR: Mising child OS  section=%s key=rs_local!\n", section);
-        tbx_flush_log();
+        tbx_log_flush();
         free(stype);
         abort();
     }
 
     //** and load it
-    ctype = tbx_inip_string_get(fd, stype, "type", OS_TYPE_FILE);
+    ctype = tbx_inip_get_string(fd, stype, "type", OS_TYPE_FILE);
     os_create = lookup_service(ess, OS_AVAILABLE, ctype);
     osrs->os_child = (*os_create)(ess, fd, stype);
     if (osrs->os_child == NULL) {
         log_printf(1, "ERROR loading child OS!  type=%s section=%s\n", ctype, stype);
-        tbx_flush_log();
+        tbx_log_flush();
         abort();
     }
     free(ctype);
@@ -3180,8 +3180,8 @@ object_service_fn_t *object_service_remote_server_create(service_manager_t *ess,
     os->type = OS_TYPE_REMOTE_SERVER;
 
     //** This is for the active tables
-    osrs->fname_active = tbx_inip_string_get(fd, section, "active_output", "/lio/log/os_active.log");
-    osrs->max_active = tbx_inip_integer_get(fd, section, "active_size", 1024);
+    osrs->fname_active = tbx_inip_get_string(fd, section, "active_output", "/lio/log/os_active.log");
+    osrs->max_active = tbx_inip_get_integer(fd, section, "active_size", 1024);
     osrs->active_table = apr_hash_make(osrs->mpool);
     osrs->active_lru = tbx_stack_new();
 

--- a/src/lio/os_test.c
+++ b/src/lio/os_test.c
@@ -1802,7 +1802,7 @@ int check_lock_state(os_fd_t *foo_fd, char **active, int n_active, char **pendin
 
     err = 0;
 
-    ifd = tbx_inip_read_string(lval);
+    ifd = tbx_inip_string_read(lval);
     grp = tbx_inip_group_find(ifd, "os.lock");
 
     ele = tbx_inip_ele_first(grp);

--- a/src/lio/os_test.c
+++ b/src/lio/os_test.c
@@ -1113,12 +1113,12 @@ void os_attribute_tests()
     rval=NULL;
     log_printf(15, "PTR1 after2 val=%s\n", val);
     log_printf(15, "PTR rval=%p *rval=%s\n", &rval, rval);
-    tbx_flush_log();
+    tbx_log_flush();
     err = gop_sync_exec(os_get_attr(os, creds, foo_fd, key, (void **)&rval, &v_size));
     log_printf(15, "PTR rval=%p *rval=%s v_size=%d\n", &rval, rval, v_size);
-    tbx_flush_log();
+    tbx_log_flush();
     log_printf(15, "PTR1 after3 val=%s\n", val);
-    tbx_flush_log();
+    tbx_log_flush();
     if (err != OP_STATE_SUCCESS) {
         nfailed++;
         log_printf(0, "ERROR: getting attr=%s err=%d\n", key, err);
@@ -1579,7 +1579,7 @@ void os_attribute_tests()
     mkey[1] = "user.bar3";
     mval[1] = "user.dummy";
     log_printf(15, "COPY_START\n");
-    tbx_flush_log();
+    tbx_log_flush();
     err = gop_sync_exec(os_copy_multiple_attrs(os, creds, foo_fd, mkey, bar_fd, mval, 2));
     if (err != OP_STATE_SUCCESS) {
         nfailed++;
@@ -1587,7 +1587,7 @@ void os_attribute_tests()
         return;
     }
     log_printf(0, "COPY_END\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
 
     //** Verify it worked
@@ -1621,7 +1621,7 @@ void os_attribute_tests()
     path[0] = foo_path;
     path[1] = foo_path;
     log_printf(15, "LINK_START\n");
-    tbx_flush_log();
+    tbx_log_flush();
     err = gop_sync_exec(os_symlink_multiple_attrs(os, creds, path, mkey, bar_fd, mval, 2));
     if (err != OP_STATE_SUCCESS) {
         nfailed++;
@@ -1710,7 +1710,7 @@ void os_attribute_tests()
         }
     }
     log_printf(15, "LINK_END\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
 
     //** Close the 2 files
@@ -1802,16 +1802,16 @@ int check_lock_state(os_fd_t *foo_fd, char **active, int n_active, char **pendin
 
     err = 0;
 
-    ifd = tbx_inip_string_read(lval);
+    ifd = tbx_inip_read_string(lval);
     grp = tbx_inip_group_find(ifd, "os.lock");
 
     ele = tbx_inip_ele_first(grp);
     ai = pi = 0;
     while (ele != NULL) {
-        key = tbx_inip_ele_key_get(ele);
+        key = tbx_inip_ele_get_key(ele);
         if (strcmp(key, "active_id") == 0) {
             if (ai < n_active) {
-                val = tbx_inip_ele_value_get(ele);
+                val = tbx_inip_ele_get_value(ele);
                 tmp = tbx_stk_string_token(val, ":", &bstate, &fin);
                 if (strcmp(tmp, active[ai]) != 0) {
                     err++;
@@ -1824,7 +1824,7 @@ int check_lock_state(os_fd_t *foo_fd, char **active, int n_active, char **pendin
             ai++;
         } else if (strcmp(key, "pending_id") == 0) {
             if (pi < n_pending) {
-                val = tbx_inip_ele_value_get(ele);
+                val = tbx_inip_ele_get_value(ele);
                 tmp = tbx_stk_string_token(val, ":", &bstate, &fin);
                 if (strcmp(tmp, pending[pi]) != 0) {
                     err++;
@@ -1966,7 +1966,7 @@ void os_locking_tests()
     dt = apr_time_now() - start;
     sec = apr_time_sec(dt);
     log_printf(0, "STATE:  active=r0,r1,r2  pending=w0,w1,a0,a1,r3,r4,w2 dt=%d\n", sec);
-    tbx_flush_log();
+    tbx_log_flush();
 
 
     //** Wait for the opens to complete
@@ -2021,7 +2021,7 @@ void os_locking_tests()
     }
 
     log_printf(0, "STATE: active=w0  pending=w1,a0,a1,r3,r4,w2\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     dt = apr_time_now() - start;
     sec = apr_time_sec(dt);
@@ -2049,7 +2049,7 @@ void os_locking_tests()
 
 
     log_printf(0, "STATE: ABORT_TIMEOUT(a0)  active=w0  pending=w1,a1,r3,r4,w2\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Let's do the aborts now
     err = gop_waitall(gop_abort[0]);  //** This should timeout on it's own
@@ -2078,7 +2078,7 @@ void os_locking_tests()
     }
 
     log_printf(0, "STATE: ABORT_CMD(a1)  active=w0  pending=w1,r3,r4,w2\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Issue an abort for a1
     err = gop_sync_exec(os_abort_open_object(os, gop_abort[1]));
@@ -2114,7 +2114,7 @@ void os_locking_tests()
     log_printf(0, "After close w0 dt=%d\n", sec);
 
     log_printf(0, "STATE: active=w1  pending=r3,r4,w2\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Wait for the opens to complete
     gop_waitany(gop_write[1]);
@@ -2140,7 +2140,7 @@ void os_locking_tests()
     log_printf(0, "After close w1 dt=%d\n", sec);
 
     log_printf(0, "STATE: active=r3,r4  pending=w2\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Wait for the opens to complete
     gop_waitany(gop_read[3]);
@@ -2170,7 +2170,7 @@ void os_locking_tests()
 
 
     log_printf(0, "STATE: active=w2  pending=\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Wait for the opens to complete
     gop_waitany(gop_write[2]);
@@ -2192,7 +2192,7 @@ void os_locking_tests()
     }
 
     log_printf(0, "Performing lock test cleanup\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Close the inital foo_fd
     err = gop_sync_exec(os_close_object(os, foo_fd));
@@ -2253,7 +2253,7 @@ int main(int argc, char **argv)
     log_printf(0, "--------------------------------------------------------------------\n");
     log_printf(0, "Using prefix=%s\n", prefix);
     log_printf(0, "--------------------------------------------------------------------\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     os_create_remove_tests();
     if (nfailed > 0) goto oops;

--- a/src/lio/os_timecache.c
+++ b/src/lio/os_timecache.c
@@ -447,7 +447,7 @@ int _ostc_cache_tree_walk(object_service_fn_t *os, char *fname, tbx_stack_t *tre
         curr = ostc->cache_root;
         tbx_stack_empty(tree, 0);
     } else {
-        curr = tbx_get_ele_data(tree);
+        curr = tbx_stack_get_current_data(tree);
     }
     tbx_stack_move_to_bottom(tree);
     tbx_stack_insert_below(tree, curr);
@@ -505,8 +505,8 @@ int _ostc_cache_tree_walk(object_service_fn_t *os, char *fname, tbx_stack_t *tre
                 } else if (n == 2) {
                     if (fname[start+1] == '.') { //** Got a ".."
                         tbx_stack_move_to_bottom(tree);
-                        tbx_delete_current(tree, 1, 0);
-                        curr = tbx_get_ele_data(tree);
+                        tbx_stack_delete_current(tree, 1, 0);
+                        curr = tbx_stack_get_current_data(tree);
                         continue;
                     }
                 }
@@ -517,14 +517,14 @@ int _ostc_cache_tree_walk(object_service_fn_t *os, char *fname, tbx_stack_t *tre
             if (fname[i] != 0) { //** If not at the end we need to follow it
                 //*** Need to make a new stack and recurse it only keeping the bottom element
                 tbx_stack_init(&rtree);
-                tbx_dup_stack(tree, &rtree);
+                tbx_stack_dup(tree, &rtree);
                 if (_ostc_cache_tree_walk(os, next->link, &rtree, NULL, add_terminal_ftype, max_recurse-1) != 0) {
                     tbx_stack_empty(&rtree, 0);
                     err = -1;
                     goto finished;
                 }
                 tbx_stack_move_to_bottom(&rtree);
-                next = tbx_get_ele_data(&rtree);  //** This will get placed as the next object on the stack
+                next = tbx_stack_get_current_data(&rtree);  //** This will get placed as the next object on the stack
                 tbx_stack_empty(&rtree, 0);
             }
         }
@@ -539,14 +539,14 @@ int _ostc_cache_tree_walk(object_service_fn_t *os, char *fname, tbx_stack_t *tre
     //** With the one provided
     if (replacement_obj != NULL) {
         tbx_stack_move_up(tree);
-        prev = tbx_get_ele_data(tree);
+        prev = tbx_stack_get_current_data(tree);
         apr_hash_set(prev->objects, curr->fname, APR_HASH_KEY_STRING, NULL);
         apr_hash_set(prev->objects, replacement_obj->fname, strlen(replacement_obj->fname), replacement_obj);
 
         free_ostcdb_object(curr);
 
         tbx_stack_move_to_bottom(tree);
-        tbx_delete_current(tree, 1, 0);
+        tbx_stack_delete_current(tree, 1, 0);
         tbx_stack_insert_below(tree, replacement_obj);
     }
 
@@ -556,7 +556,7 @@ finished:
     ostcdb_object_t *lo;
     tbx_stack_move_to_top(tree);
     log_printf(15, "stack_size=%d\n", tbx_stack_size(tree));
-    while ((lo = tbx_get_ele_data(tree)) != NULL) {
+    while ((lo = tbx_stack_get_current_data(tree)) != NULL) {
         log_printf(15, "pwalk lo=%s ftype=%d\n", lo->fname, lo->ftype);
         tbx_stack_move_down(tree);
     }
@@ -596,11 +596,11 @@ int _ostcdb_resolve_attr_link(object_service_fn_t *os, tbx_stack_t *tree, char *
 
     //** Copy the stack
     tbx_stack_init(&rtree);
-    tbx_dup_stack(&rtree, tree);
+    tbx_stack_dup(&rtree, tree);
 
     tbx_stack_move_to_top(&rtree);
     log_printf(5, "stack_size=%d org=%d\n", tbx_stack_size(&rtree), tbx_stack_size(tree));
-    while ((lo = tbx_get_ele_data(&rtree)) != NULL) {
+    while ((lo = tbx_stack_get_current_data(&rtree)) != NULL) {
         log_printf(5, "pwalk lo=%s ftype=%d\n", lo->fname, lo->ftype);
         tbx_stack_move_down(&rtree);
     }
@@ -608,14 +608,14 @@ int _ostcdb_resolve_attr_link(object_service_fn_t *os, tbx_stack_t *tree, char *
 
     //** and pop the terminal which is up.  This will pop us up to the directory for the walk
     tbx_stack_move_to_bottom(&rtree);
-    tbx_delete_current(&rtree, 1, 0);
+    tbx_stack_delete_current(&rtree, 1, 0);
     if (_ostc_cache_tree_walk(os, alink, &rtree, NULL, 0, OSTC_MAX_RECURSE) != 0) {
         if (i> -1) alink[i] = '/';
         goto finished;
     }
     if (i> -1) alink[i] = '/'; //** Undo our string munge if needed
     tbx_stack_move_to_bottom(&rtree);
-    lo = tbx_get_ele_data(&rtree);  //** This will get placed as the next object on the stack
+    lo = tbx_stack_get_current_data(&rtree);  //** This will get placed as the next object on the stack
 
     if (lo == NULL) goto finished;
     la = apr_hash_get(lo->attrs, aname, APR_HASH_KEY_STRING);
@@ -654,7 +654,7 @@ void ostc_cache_move_object(object_service_fn_t *os, creds_t *creds, char *src_p
     OSTC_LOCK(ostc);
     if (_ostc_cache_tree_walk(os, src_path, &stree, NULL, 0, OSTC_MAX_RECURSE) == 0) {
         tbx_stack_move_to_bottom(&stree);
-        obj = tbx_get_ele_data(&stree);
+        obj = tbx_stack_get_current_data(&stree);
         tbx_stack_init(&dtree);
         _ostc_cache_tree_walk(os, src_path, &dtree, obj, obj->ftype, OSTC_MAX_RECURSE);  //** Do the walk and substitute
         tbx_stack_empty(&dtree, 0);
@@ -679,9 +679,9 @@ void ostc_cache_remove_object(object_service_fn_t *os, char *path)
     OSTC_LOCK(ostc);
     if (_ostc_cache_tree_walk(os, path, &tree, NULL, 0, OSTC_MAX_RECURSE) == 0) {
         tbx_stack_move_to_bottom(&tree);
-        obj = tbx_get_ele_data(&tree);
+        obj = tbx_stack_get_current_data(&tree);
         tbx_stack_move_up(&tree);
-        parent = tbx_get_ele_data(&tree);
+        parent = tbx_stack_get_current_data(&tree);
         apr_hash_set(parent->objects, obj->fname, APR_HASH_KEY_STRING, NULL);
         free_ostcdb_object(obj);
     }
@@ -709,7 +709,7 @@ void ostc_cache_remove_attrs(object_service_fn_t *os, char *fname, char **key, i
     if (_ostc_cache_tree_walk(os, fname, &tree, NULL, 0, OSTC_MAX_RECURSE) != 0) goto finished;
 
     tbx_stack_move_to_bottom(&tree);
-    obj = tbx_get_ele_data(&tree);
+    obj = tbx_stack_get_current_data(&tree);
     for (i=0; i<n; i++) {
         attr = apr_hash_get(obj->attrs, key[i], APR_HASH_KEY_STRING);
         if (attr != NULL) {
@@ -742,7 +742,7 @@ void ostc_cache_move_attrs(object_service_fn_t *os, char *fname, char **key_old,
     if (_ostc_cache_tree_walk(os, fname, &tree, NULL, 0, OSTC_MAX_RECURSE) != 0) goto finished;
 
     tbx_stack_move_to_bottom(&tree);
-    obj = tbx_get_ele_data(&tree);
+    obj = tbx_stack_get_current_data(&tree);
     for (i=0; i<n; i++) {
         attr = apr_hash_get(obj->attrs, key_old[i], APR_HASH_KEY_STRING);
         if (attr != NULL) {
@@ -787,7 +787,7 @@ void ostc_cache_process_attrs(object_service_fn_t *os, char *fname, int ftype, c
     log_printf(5, "fname=%s stack_size=%d\n", fname, tbx_stack_size(&tree));
 
     tbx_stack_move_to_bottom(&tree);
-    obj = tbx_get_ele_data(&tree);
+    obj = tbx_stack_get_current_data(&tree);
 
     if (obj->link) {
         free(obj->link);
@@ -884,7 +884,7 @@ op_status_t ostc_cache_fetch(object_service_fn_t *os, char *fname, char **key, v
     if (_ostc_cache_tree_walk(os, fname, &tree, NULL, 0, OSTC_MAX_RECURSE) != 0) goto finished;
 
     tbx_stack_move_to_bottom(&tree);
-    obj = tbx_get_ele_data(&tree);
+    obj = tbx_stack_get_current_data(&tree);
     oops = 1;
     for (i=0; i<n; i++) {
         attr = apr_hash_get(obj->attrs, key[i], APR_HASH_KEY_STRING);
@@ -952,7 +952,7 @@ void ostc_cache_update_attrs(object_service_fn_t *os, char *fname, char **key, v
     if (_ostc_cache_tree_walk(os, fname, &tree, NULL, 0, OSTC_MAX_RECURSE) != 0) goto finished;
 
     tbx_stack_move_to_bottom(&tree);
-    obj = tbx_get_ele_data(&tree);
+    obj = tbx_stack_get_current_data(&tree);
     for (i=0; i<n; i++) {
         attr = apr_hash_get(obj->attrs, key[i], APR_HASH_KEY_STRING);
         if (attr == NULL) continue;  //** Not in cache so ignore updating it
@@ -2185,9 +2185,9 @@ object_service_fn_t *object_service_timecache_create(service_manager_t *ess, tbx
     tbx_type_malloc_clear(ostc, ostc_priv_t, 1);
     os->priv = (void *)ostc;
 
-    str = tbx_inip_string_get(fd, section, "os_child", NULL);
+    str = tbx_inip_get_string(fd, section, "os_child", NULL);
     if (str != NULL) {  //** Running in test/temp
-        ctype = tbx_inip_string_get(fd, str, "type", OS_TYPE_REMOTE_CLIENT);
+        ctype = tbx_inip_get_string(fd, str, "type", OS_TYPE_REMOTE_CLIENT);
         os_create = lookup_service(ess, OS_AVAILABLE, ctype);
         ostc->os_child = (*os_create)(ess, fd, str);
         if (ostc->os_child == NULL) {
@@ -2203,8 +2203,8 @@ object_service_fn_t *object_service_timecache_create(service_manager_t *ess, tbx
         abort();
     }
 
-    ostc->entry_timeout = apr_time_from_sec(tbx_inip_integer_get(fd, section, "entry_timeout", 20));
-    ostc->cleanup_interval = apr_time_from_sec(tbx_inip_integer_get(fd, section, "cleanup_interval", 120));
+    ostc->entry_timeout = apr_time_from_sec(tbx_inip_get_integer(fd, section, "entry_timeout", 20));
+    ostc->cleanup_interval = apr_time_from_sec(tbx_inip_get_integer(fd, section, "cleanup_interval", 120));
 
     apr_pool_create(&ostc->mpool, NULL);
     apr_thread_mutex_create(&(ostc->lock), APR_THREAD_MUTEX_DEFAULT, ostc->mpool);

--- a/src/lio/os_timecache.c
+++ b/src/lio/os_timecache.c
@@ -443,7 +443,7 @@ int _ostc_cache_tree_walk(object_service_fn_t *os, char *fname, tbx_stack_t *tre
     if ((fname == NULL) || (max_recurse <= 0)) return(1);
 
     i=0;
-    if ((tbx_stack_size(tree) == 0) || (fname[i] == '/')) {
+    if ((tbx_stack_count(tree) == 0) || (fname[i] == '/')) {
         curr = ostc->cache_root;
         tbx_stack_empty(tree, 0);
     } else {
@@ -555,7 +555,7 @@ finished:
     log_printf(15, "fname=%s err=%d\n", fname, err);
     ostcdb_object_t *lo;
     tbx_stack_move_to_top(tree);
-    log_printf(15, "stack_size=%d\n", tbx_stack_size(tree));
+    log_printf(15, "stack_size=%d\n", tbx_stack_count(tree));
     while ((lo = tbx_stack_get_current_data(tree)) != NULL) {
         log_printf(15, "pwalk lo=%s ftype=%d\n", lo->fname, lo->ftype);
         tbx_stack_move_down(tree);
@@ -599,7 +599,7 @@ int _ostcdb_resolve_attr_link(object_service_fn_t *os, tbx_stack_t *tree, char *
     tbx_stack_dup(&rtree, tree);
 
     tbx_stack_move_to_top(&rtree);
-    log_printf(5, "stack_size=%d org=%d\n", tbx_stack_size(&rtree), tbx_stack_size(tree));
+    log_printf(5, "stack_size=%d org=%d\n", tbx_stack_count(&rtree), tbx_stack_count(tree));
     while ((lo = tbx_stack_get_current_data(&rtree)) != NULL) {
         log_printf(5, "pwalk lo=%s ftype=%d\n", lo->fname, lo->ftype);
         tbx_stack_move_down(&rtree);
@@ -784,7 +784,7 @@ void ostc_cache_process_attrs(object_service_fn_t *os, char *fname, int ftype, c
     OSTC_LOCK(ostc);
     if (_ostc_cache_tree_walk(os, fname, &tree, NULL, ftype, OSTC_MAX_RECURSE) != 0) goto finished;
 
-    log_printf(5, "fname=%s stack_size=%d\n", fname, tbx_stack_size(&tree));
+    log_printf(5, "fname=%s stack_size=%d\n", fname, tbx_stack_count(&tree));
 
     tbx_stack_move_to_bottom(&tree);
     obj = tbx_stack_get_current_data(&tree);

--- a/src/lio/rs_remote_client.c
+++ b/src/lio/rs_remote_client.c
@@ -275,7 +275,7 @@ op_generic_t *rsrc_update_config_op(resource_service_fn_t *rs, int mode, int tim
     tbx_type_malloc_clear(arg, rsrc_gop_rid_config_t, 1);
 
     //** Form the message
-    tbx_random_bytes_get(&(arg->id), sizeof(arg->id));
+    tbx_random_get_bytes(&(arg->id), sizeof(arg->id));
     if (mode != 0) rsrc->update_id = arg->id;  //** Only update the id for an actual wait and update
     msg = mq_msg_new();
     mq_msg_append_mem(msg, rsrc->host_remote_rs, strlen(rsrc->host_remote_rs), MQF_MSG_KEEP_DATA);
@@ -388,7 +388,7 @@ void *rsrc_check_thread(apr_thread_t *th, void *data)
         log_printf(15, "before gop_timed_waitany gid=%d timeout=%d\n", gop_id(gop), rsrc->check_interval);
         g = gop_timed_waitany(gop, 1);
         log_printf(15, "after gop_waitany g=%p\n", g);
-        tbx_flush_log();
+        tbx_log_flush();
 
         apr_thread_mutex_lock(rsrc->lock);
         n = rsrc->shutdown;
@@ -397,7 +397,7 @@ void *rsrc_check_thread(apr_thread_t *th, void *data)
         if (g != NULL) {
             status = gop_get_status(gop);
             log_printf(15, "update completed status=%d\n", status.op_status);
-            tbx_flush_log();
+            tbx_log_flush();
             gop_free(gop, OP_DESTROY);
             gop = NULL;
         }
@@ -433,7 +433,7 @@ void rs_remote_client_destroy(resource_service_fn_t *rs)
     apr_thread_mutex_lock(rsrc->lock);
     rsrc->shutdown = 1;
     log_printf(15, "SHUTDOWN rsrc->shutdown=%d\n", rsrc->shutdown);
-    tbx_flush_log();
+    tbx_log_flush();
 
     _rsrc_update_abort(rs);  //** Abort any pending check
     apr_thread_mutex_unlock(rsrc->lock);
@@ -478,23 +478,23 @@ resource_service_fn_t *rs_remote_client_create(void *arg, tbx_inip_file_t *fd, c
     apr_thread_cond_create(&(rsrc->cond), rsrc->mpool);
 
     //** Now get the other params
-    rsrc->child_target_file = tbx_inip_string_get(fd, section, "child_fname", NULL);
-    rsrc->host_remote_rs = tbx_inip_string_get(fd, section, "remote_address", NULL);
-    rsrc->dynamic_mapping = tbx_inip_integer_get(fd, section, "dynamic_mapping", 0);
-    rsrc->check_interval = tbx_inip_integer_get(fd, section, "check_interval", 3600);
+    rsrc->child_target_file = tbx_inip_get_string(fd, section, "child_fname", NULL);
+    rsrc->host_remote_rs = tbx_inip_get_string(fd, section, "remote_address", NULL);
+    rsrc->dynamic_mapping = tbx_inip_get_integer(fd, section, "dynamic_mapping", 0);
+    rsrc->check_interval = tbx_inip_get_integer(fd, section, "check_interval", 3600);
 
     //** Get the MQC
     rsrc->mqc = lookup_service(ess, ESS_RUNNING, ESS_MQ); assert(rsrc->mqc != NULL);
 
     //** Check if we are running the remote RS locally.  This means we are doing testing
-    stype = tbx_inip_string_get(fd, section, "rrs_test", NULL);
+    stype = tbx_inip_get_string(fd, section, "rrs_test", NULL);
     if (stype != NULL) {
-        ctype = tbx_inip_string_get(fd, stype, "type", RS_TYPE_SIMPLE);
+        ctype = tbx_inip_get_string(fd, stype, "type", RS_TYPE_SIMPLE);
         rs_create = lookup_service(ess, RS_SM_AVAILABLE, ctype);
         rsrc->rrs_test = (*rs_create)(ess, fd, stype);
         if (rsrc->rrs_test == NULL) {
             log_printf(1, "ERROR loading test RRS!  type=%s section=%s\n", ctype, stype);
-            tbx_flush_log();
+            tbx_log_flush();
             abort();
         }
         free(ctype);
@@ -504,7 +504,7 @@ resource_service_fn_t *rs_remote_client_create(void *arg, tbx_inip_file_t *fd, c
     //** Contact the Remote RS and get the initial config
     if (_rsrc_update_config(rs) != 0) {
         log_printf(0, "ERROR: Remote RS is down!  section=%s remote_host=%s!\n", section, rsrc->host_remote_rs);
-        tbx_flush_log();
+        tbx_log_flush();
         abort();
     }
 
@@ -519,26 +519,26 @@ resource_service_fn_t *rs_remote_client_create(void *arg, tbx_inip_file_t *fd, c
     }
     if (loop>=300) {
         log_printf(0, "ERROR: Remote RS is down! Unable to get cleint config from server! section=%s remote_host=%s!\n", section, rsrc->host_remote_rs);
-        tbx_flush_log();
+        tbx_log_flush();
         abort();
     }
 
     //** Start the child RS.   The update above should have dumped a RID config for it to load
-    stype = tbx_inip_string_get(fd, section, "rs_local", NULL);
+    stype = tbx_inip_get_string(fd, section, "rs_local", NULL);
     if (stype == NULL) {  //** Oops missing child RS
         log_printf(0, "ERROR: Mising child RS  section=%s key=rs_local!\n", section);
-        tbx_flush_log();
+        tbx_log_flush();
         free(stype);
         abort();
     }
 
     //** and load it
-    ctype = tbx_inip_string_get(fd, stype, "type", RS_TYPE_SIMPLE);
+    ctype = tbx_inip_get_string(fd, stype, "type", RS_TYPE_SIMPLE);
     rs_create = lookup_service(ess, RS_SM_AVAILABLE, ctype);
     rsrc->rs_child = (*rs_create)(ess, fd, stype);
     if (rsrc->rs_child == NULL) {
         log_printf(1, "ERROR loading child RS!  type=%s section=%s\n", ctype, stype);
-        tbx_flush_log();
+        tbx_log_flush();
         abort();
     }
     free(ctype);

--- a/src/lio/rs_remote_server.c
+++ b/src/lio/rs_remote_server.c
@@ -434,7 +434,7 @@ void *rsrs_monitor_thread(apr_thread_t *th, void *data)
         }
         shutdown = rsrs->shutdown;
         wakeup_time = rsrs->wakeup_time;
-        log_printf(5, "checking.... pending=%d now=" TT " wakeup=" TT "\n", tbx_stack_size(rsrs->pending), apr_time_now(), wakeup_time);
+        log_printf(5, "checking.... pending=%d now=" TT " wakeup=" TT "\n", tbx_stack_count(rsrs->pending), apr_time_now(), wakeup_time);
         apr_thread_mutex_unlock(rsrs->lock);
 
         if (changed == 1) { //** RID table has changed so propagate it to everone

--- a/src/lio/rs_simple.c
+++ b/src/lio/rs_simple.c
@@ -880,7 +880,7 @@ int _rs_simple_load(resource_service_fn_t *res, char *fname)
     log_printf(5, "START fname=%s n_rids=%d\n", fname, rss->n_rids);
 
     //** Open the file
-    kf = tbx_inip_read_file(fname); assert(kf);
+    kf = tbx_inip_file_read(fname); assert(kf);
 
     //** Create the new RS list
     rss->rid_table = tbx_list_create(0, &tbx_list_string_compare, NULL, NULL, rs_simple_rid_free);

--- a/src/lio/rs_simple.c
+++ b/src/lio/rs_simple.c
@@ -212,7 +212,7 @@ op_generic_t *rs_simple_request(resource_service_fn_t *arg, data_attr_t *da, rs_
     rs_query_count(arg, rsq, &i, &(kvq_global.n_unique), &(kvq_global.n_pickone));
 
     log_printf(15, "rs_simple_request: n_unique=%d n_pickone=%d\n", kvq_global.n_unique, kvq_global.n_pickone);
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Make space the for the uniq and pickone fields.
     //** Make sure we have space for at least 1 more than we need of each to pass to the routines even though they aren't used
@@ -246,7 +246,7 @@ op_generic_t *rs_simple_request(resource_service_fn_t *arg, data_attr_t *da, rs_
         found = 0;
         loop_end = 1;
         query_local = NULL;
-        rnd_off = tbx_random_int64(0, rss->n_rids-1);
+        rnd_off = tbx_random_get_int64(0, rss->n_rids-1);
 //rnd_off = 0;  //FIXME
 
         if (hints_list != NULL) {
@@ -317,7 +317,7 @@ op_generic_t *rs_simple_request(resource_service_fn_t *arg, data_attr_t *da, rs_
                     case RSQ_BASE_OP_KV:
                         state = rss_test(q, rse, i, kvq->unique[i_unique], &(kvq->pickone[i_pickone]));
                         log_printf(0, "KV: key=%s val=%s i_unique=%d i_pickone=%d loop=%d rss_test=%d rse->rid_key=%s\n", q->key, q->val, i_unique, i_pickone, loop, state, rse->rid_key);
-                        tbx_flush_log();
+                        tbx_log_flush();
                         if ((q->key_op & RSQ_BASE_KV_UNIQUE) || (q->val_op & RSQ_BASE_KV_UNIQUE)) i_unique++;
                         if ((q->key_op & RSQ_BASE_KV_PICKONE) || (q->val_op & RSQ_BASE_KV_PICKONE)) i_pickone++;
                         break;
@@ -349,7 +349,7 @@ op_generic_t *rs_simple_request(resource_service_fn_t *arg, data_attr_t *da, rs_
                     *op_state = state;
                     tbx_stack_push(stack, (void *)op_state);
                     log_printf(15, " stack_size=%d loop=%d push state=%d\n",tbx_stack_size(stack), loop, state);
-                    tbx_flush_log();
+                    tbx_log_flush();
                     q = q->next;
                 }
 
@@ -423,7 +423,7 @@ op_generic_t *rs_simple_request(resource_service_fn_t *arg, data_attr_t *da, rs_
     free(kvq_local.unique);
     free(kvq_local.pickone);
 
-    tbx_free_stack(stack, 1);
+    tbx_stack_free(stack, 1);
 
     log_printf(15, "rs_simple_request: END n_rid=%d\n", n_rid);
 
@@ -480,7 +480,7 @@ void rs_simple_rid_free(tbx_list_data_t *arg)
     rss_rid_entry_t *rse = (rss_rid_entry_t *)arg;
 
     log_printf(15, "START\n");
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (rse == NULL) return;
 
@@ -513,8 +513,8 @@ rss_rid_entry_t *rss_load_entry(tbx_inip_group_t *grp)
     //** Now cycle through the attributes
     ele = tbx_inip_ele_first(grp);
     while (ele != NULL) {
-        key = tbx_inip_ele_key_get(ele);
-        value = tbx_inip_ele_value_get(ele);
+        key = tbx_inip_ele_get_key(ele);
+        value = tbx_inip_ele_get_value(ele);
         if (strcmp(key, "rid_key") == 0) {  //** This is the RID so store it separate
             rse->rid_key = strdup(value);
             tbx_list_insert(rse->attr, key, rse->rid_key);
@@ -672,7 +672,7 @@ void rss_mapping_notify(resource_service_fn_t *rs, int new_version, int status_c
     apr_ssize_t klen;
     void *rid;
 
-    if (status_change > 0) status_change = tbx_random_int64(0, 100000);
+    if (status_change > 0) status_change = tbx_random_get_int64(0, 100000);
 
     apr_thread_mutex_lock(rss->update_lock);
     for (hi = apr_hash_first(NULL, rss->mapping_updates); hi != NULL; hi = apr_hash_next(hi)) {
@@ -880,7 +880,7 @@ int _rs_simple_load(resource_service_fn_t *res, char *fname)
     log_printf(5, "START fname=%s n_rids=%d\n", fname, rss->n_rids);
 
     //** Open the file
-    kf = tbx_inip_file_read(fname); assert(kf);
+    kf = tbx_inip_read_file(fname); assert(kf);
 
     //** Create the new RS list
     rss->rid_table = tbx_list_create(0, &tbx_list_string_compare, NULL, NULL, rs_simple_rid_free);
@@ -911,7 +911,7 @@ int _rs_simple_load(resource_service_fn_t *res, char *fname)
         for (i=0; i < rss->n_rids; i++) {
             tbx_list_next(&it, (tbx_list_key_t **)&key, (tbx_list_data_t **)&rse);
 
-            n = tbx_random_int64(0, rss->n_rids-1);
+            n = tbx_random_get_int64(0, rss->n_rids-1);
 //n = i;  //FIXME
             while (rss->random_array[n] != NULL) {
                 n = (n+1) % rss->n_rids;
@@ -971,7 +971,7 @@ void rs_simple_destroy(resource_service_fn_t *rs)
     apr_status_t value;
 
     log_printf(15, "rs_simple_destroy: sl=%p\n", rss->rid_table);
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Notify the depot check thread
     apr_thread_mutex_lock(rss->lock);
@@ -1039,11 +1039,11 @@ resource_service_fn_t *rs_simple_create(void *arg, tbx_inip_file_t *kf, char *se
     rs->type = RS_TYPE_SIMPLE;
 
     //** This is the file to use for loading the RID table
-    rss->fname = tbx_inip_string_get(kf, section, "fname", NULL);
-    rss->dynamic_mapping = tbx_inip_integer_get(kf, section, "dynamic_mapping", 0);
-    rss->check_interval = tbx_inip_integer_get(kf, section, "check_interval", 300);
-    rss->check_timeout = tbx_inip_integer_get(kf, section, "check_timeout", 60);
-    rss->min_free = tbx_inip_integer_get(kf, section, "min_free", 100*1024*1024);
+    rss->fname = tbx_inip_get_string(kf, section, "fname", NULL);
+    rss->dynamic_mapping = tbx_inip_get_integer(kf, section, "dynamic_mapping", 0);
+    rss->check_interval = tbx_inip_get_integer(kf, section, "check_interval", 300);
+    rss->check_timeout = tbx_inip_get_integer(kf, section, "check_timeout", 60);
+    rss->min_free = tbx_inip_get_integer(kf, section, "min_free", 100*1024*1024);
 
     //** Set the modify time to force a change
     rss->modify_time = 0;

--- a/src/lio/rs_simple.c
+++ b/src/lio/rs_simple.c
@@ -348,7 +348,7 @@ op_generic_t *rs_simple_request(resource_service_fn_t *arg, data_attr_t *da, rs_
                     tbx_type_malloc(op_state, int, 1);
                     *op_state = state;
                     tbx_stack_push(stack, (void *)op_state);
-                    log_printf(15, " stack_size=%d loop=%d push state=%d\n",tbx_stack_size(stack), loop, state);
+                    log_printf(15, " stack_size=%d loop=%d push state=%d\n",tbx_stack_count(stack), loop, state);
                     tbx_log_flush();
                     q = q->next;
                 }

--- a/src/lio/rs_space.c
+++ b/src/lio/rs_space.c
@@ -41,7 +41,7 @@ rs_space_t rs_space(char *config)
 
     if (config == NULL) return(space);
 
-    fd = tbx_inip_string_read(config); assert(fd);
+    fd = tbx_inip_read_string(config); assert(fd);
 
     grp = tbx_inip_group_first(fd);
     while (grp != NULL) {
@@ -52,8 +52,8 @@ rs_space_t rs_space(char *config)
             ele = tbx_inip_ele_first(grp);
             status = nfree = nused = ntotal = 0;
             while (ele != NULL) {
-                key = tbx_inip_ele_key_get(ele);
-                value = tbx_inip_ele_value_get(ele);
+                key = tbx_inip_ele_get_key(ele);
+                value = tbx_inip_ele_get_value(ele);
                 if (strcmp(key, "space_free") == 0) {  //** Space free
                     nfree = tbx_stk_string_get_integer(value);
                     if (nfree > 0) space.n_rids_free++;

--- a/src/lio/rs_space.c
+++ b/src/lio/rs_space.c
@@ -41,7 +41,7 @@ rs_space_t rs_space(char *config)
 
     if (config == NULL) return(space);
 
-    fd = tbx_inip_read_string(config); assert(fd);
+    fd = tbx_inip_string_read(config); assert(fd);
 
     grp = tbx_inip_group_first(fd);
     while (grp != NULL) {

--- a/src/lio/rs_test_svr.c
+++ b/src/lio/rs_test_svr.c
@@ -65,9 +65,9 @@ int main(int argc, char **argv)
     char *svr_proto, *svr_addr, *svr_port, *zmq_svr;
 
     //** Retrieves remote zmq server name, transport protocol, and lisenting port
-    svr_proto = tbx_inip_string_get(lio_gc->ifd, "zmq_server", "protocol", RS_ZMQ_DFT_PROTO);
-    svr_addr = tbx_inip_string_get(lio_gc->ifd, "zmq_server", "server", NULL);
-    svr_port = tbx_inip_string_get(lio_gc->ifd, "zmq_server", "port", RS_ZMQ_DFT_PORT);
+    svr_proto = tbx_inip_get_string(lio_gc->ifd, "zmq_server", "protocol", RS_ZMQ_DFT_PROTO);
+    svr_addr = tbx_inip_get_string(lio_gc->ifd, "zmq_server", "server", NULL);
+    svr_port = tbx_inip_get_string(lio_gc->ifd, "zmq_server", "port", RS_ZMQ_DFT_PORT);
     asprintf(&zmq_svr, "%s://%s:%s", tbx_stk_string_trim(svr_proto), tbx_stk_string_trim(svr_addr), tbx_stk_string_trim(svr_port));
 
 

--- a/src/lio/rs_zmq.c
+++ b/src/lio/rs_zmq.c
@@ -205,7 +205,7 @@ resource_service_fn_t *rs_zmq_create(void *arg, tbx_inip_file_t *kf, char *secti
 service_manager_t *ess = (service_manager_t *)arg;
  
 log_printf(15, "START!!!!!!!!!!!!!!!!!!\n"); 
-tbx_flush_log();
+tbx_log_flush();
 //** Creates zmq context
 void *context = zmq_ctx_new();
 assert(context != NULL);
@@ -227,9 +227,9 @@ rsz->tpc = lookup_service(ess, ESS_RUNNING, ESS_TPC_UNLIMITED); //** Refers to l
 char *svr_proto, *svr_addr, *svr_port;
  
 //** Retrieves remote zmq server name, transport protocol, and lisenting port
-svr_proto = tbx_inip_string_get(kf, section, "protocol", RS_ZMQ_DFT_PROTO);
-svr_addr = tbx_inip_string_get(kf, section, "server", NULL);
-svr_port = tbx_inip_string_get(kf, section, "port", RS_ZMQ_DFT_PORT);
+svr_proto = tbx_inip_get_string(kf, section, "protocol", RS_ZMQ_DFT_PROTO);
+svr_addr = tbx_inip_get_string(kf, section, "server", NULL);
+svr_port = tbx_inip_get_string(kf, section, "port", RS_ZMQ_DFT_PORT);
 asprintf(&rsz->zmq_svr, "%s://%s:%s", tbx_stk_string_trim(svr_proto), tbx_stk_string_trim(svr_addr), tbx_stk_string_trim(svr_port));
  
 free(svr_proto);

--- a/src/lio/segment_base.c
+++ b/src/lio/segment_base.c
@@ -55,7 +55,7 @@ segment_t *load_segment(service_manager_t *ess, ex_id_t id, exnode_exchange_t *e
     if (ex->type == EX_TEXT) {
         snprintf(name, sizeof(name), "segment-" XIDT, id);
         tbx_inip_file_t *fd = ex->text.fd;
-        type = tbx_inip_string_get(fd, name, "type", "");
+        type = tbx_inip_get_string(fd, name, "type", "");
     } else if (ex->type == EX_PROTOCOL_BUFFERS) {
         log_printf(0, "load_segment:  segment exnode parsing goes here\n");
     } else {

--- a/src/lio/segment_cache.c
+++ b/src/lio/segment_cache.c
@@ -164,7 +164,7 @@ void flush_wait(segment_t *seg, ex_off_t *my_flush)
     do {
         finished = 1;
         tbx_stack_move_to_bottom(s->flush_stack);
-        while ((check = (ex_off_t *)tbx_get_ele_data(s->flush_stack)) != NULL) {
+        while ((check = (ex_off_t *)tbx_stack_get_current_data(s->flush_stack)) != NULL) {
 //log_printf(0, "check[2]=" XOT " me[2]=" XOT "\n", check[2], my_flush[2]);
 
             if (check[2] < my_flush[2]) {
@@ -380,7 +380,7 @@ int cache_rw_pages(segment_t *seg, segment_rw_hints_t *rw_hints, page_handle_t *
                 cio->gop = segment_write(s->child_seg, s->c->da, rw_hints, 1, &(cio->ex_iov), &(cio->buf), 0, s->c->timeout);
             }
             log_printf(2, "rw_mode=%d gid=%d offset=" XOT " len=" XOT "\n", rw_mode, gop_id(cio->gop), plist[contig_start].p->offset, cio->nbytes);
-            tbx_flush_log();
+            tbx_log_flush();
 
             gop_set_myid(cio->gop, myid);
             gop_set_private(cio->gop, (void *)cio);
@@ -441,7 +441,7 @@ int cache_rw_pages(segment_t *seg, segment_rw_hints_t *rw_hints, page_handle_t *
         }
         log_printf(2, "end rw_mode=%d gid=%d offset=" XOT " len=" XOT "\n", rw_mode, gop_id(cio->gop), plist[contig_start].p->offset, cio->nbytes);
         log_printf(15, "end rw_mode=%d myid=%d gid=%d\n", rw_mode, myid, gop_id(cio->gop));
-        tbx_flush_log();
+        tbx_log_flush();
 
         gop_set_myid(cio->gop, myid);
         gop_set_private(cio->gop, (void *)cio);
@@ -471,18 +471,18 @@ int cache_rw_pages(segment_t *seg, segment_rw_hints_t *rw_hints, page_handle_t *
     //** Process tasks as they complete
     n = opque_task_count(q);
     log_printf(15, "cache_rw_pages: total tasks=%d\n", n);
-    tbx_flush_log();
+    tbx_log_flush();
 
     for (i=0; i<n; i++) {
         gop = opque_waitany(q);
         myid= gop_get_myid(gop);
         log_printf(15, "cache_rw_pages: myid=%d gid=%d completed\n", myid, gop_id(gop));
-        tbx_flush_log();
+        tbx_log_flush();
 
         cio = gop_get_private(gop);
         if (gop_completed_successfully(gop) != OP_STATE_SUCCESS) {
             log_printf(15, "cache_rw_pages: myid=%d gid=%d completed with errors!\n", myid, gop_id(gop));
-            tbx_flush_log();
+            tbx_log_flush();
 
             if (rw_mode == CACHE_READ) {
                 for (j=0; j<cio->n_iov; j++) {
@@ -543,10 +543,10 @@ cache_page_t  *cache_page_force_get(segment_t *seg, segment_rw_hints_t *rw_hints
 
     p = tbx_list_search(s->pages, (tbx_sl_key_t *)(&off_row));
     log_printf(15, "cache_page_force_get: seg=" XIDT " offset=" XOT " p=%p count=%d\n", segment_id(seg), poff, p, tbx_sl_key_count(s->pages));
-    tbx_flush_log();
+    tbx_log_flush();
     if (p == NULL) {  //** New page so may need to load it
         log_printf(15, "seg=" XIDT " offset=" XOT ". Not there so create it. count=%d\n", segment_id(seg), poff, tbx_sl_key_count(s->pages));
-        tbx_flush_log();
+        tbx_log_flush();
         p = s->c->fn.create_empty_page(s->c, seg, 1);  //** Get the empty page
         p->seg = seg;
 
@@ -663,27 +663,27 @@ op_status_t cache_advise_fn(void *arg, int id)
         err = 0;
         if (p == NULL) {  //** End of range and no pages
             log_printf(15, "seg=" XIDT " coff=" XOT "p->offset=NULL err=1\n", segment_id(seg), coff);
-            tbx_flush_log();
+            tbx_log_flush();
             err = 1;
         } else if (p->offset != coff) {  //** Missing page
             err = 1;
             log_printf(15, "seg=" XIDT " coff=" XOT "p->offset=" XOT " err=1\n", segment_id(seg), coff, p->offset);
-            tbx_flush_log();
+            tbx_log_flush();
         } else {
             log_printf(15, "seg=" XIDT " coff=" XOT "p->offset=" XOT " err=0\n", segment_id(seg), coff, p->offset);
-            tbx_flush_log();
+            tbx_log_flush();
         }
 
         //** If needed add the empty page
         if (err == 1) {
             log_printf(15, "seg=" XIDT " attempting to create page coff=" XOT "\n", segment_id(seg), coff);
-            tbx_flush_log();
+            tbx_log_flush();
             np = s->c->fn.create_empty_page(s->c, seg, 0);  //** Get the empty page
             if ((np == NULL) && (ca->force_wait == 1) && (*ca->n_pages == 0)) {  //**may need to force a page to be created
                 np = s->c->fn.create_empty_page(s->c, seg, ca->force_wait);  //** Get the empty page
             }
             log_printf(15, "seg=" XIDT " after attempt to create page coff=" XOT " new_page=%p\n", segment_id(seg), coff, np);
-            tbx_flush_log();
+            tbx_log_flush();
             if (np != NULL) { //** This was an opportunistic request so it could be denied
                 //** During the page creation we may have released and reacquired the lock letting another thread insert the page
                 p2 = tbx_list_search(s->pages, (tbx_sl_key_t *)(&coff));
@@ -698,12 +698,12 @@ op_status_t cache_advise_fn(void *arg, int id)
                     if (*ca->n_pages >= max_pages) break;
                 } else {   //** Somebody else beat me to it so skip it
                     log_printf(5, "seg=" XIDT " duplicate page for coff=" XOT "\n", segment_id(seg), coff);
-                    tbx_flush_log();
+                    tbx_log_flush();
                     s->c->fn.destroy_pages(s->c, &np, 1, 0);  //** Destroy my page
                 }
             } else {
                 log_printf(15, "seg=" XIDT " cant find the space for coff=" XOT " so stopping scan\n", segment_id(seg), coff);
-                tbx_flush_log();
+                tbx_log_flush();
                 break;
             }
 
@@ -1220,7 +1220,7 @@ int cache_read_pages_get(segment_t *seg, segment_rw_hints_t *rw_hints, int mode,
 
     if ((*n_pages == 0) && (n == 0)) skip_mode = 1;
     log_printf(15, "END seg=" XIDT " mode=%d lo=" XOT " hi=" XOT " hi_got=" XOT " skip_mode=%d n_pages=%d\n", segment_id(seg), mode, lo, hi, *hi_got, skip_mode, *n_pages);
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(skip_mode);
 }
@@ -1273,7 +1273,7 @@ int cache_write_pages_get(segment_t *seg, segment_rw_hints_t *rw_hints, int mode
         err = 1;
     } else if (*poff != lo_row) { //** Should find an exact match otherwise it's a hole
         log_printf(15, "seg=" XIDT " initial page p->offset=" XOT "\n", segment_id(seg), *poff);
-        tbx_flush_log();
+        tbx_log_flush();
 
         pcheck.p = p;
         pcheck.data = p->curr_data;
@@ -1655,9 +1655,9 @@ int cache_write_pages_get(segment_t *seg, segment_rw_hints_t *rw_hints, int mode
     log_printf(15, "END seg=" XIDT " mode=%d lo=" XOT " hi=" XOT " hi_got=" XOT " skip_mode=%d n_pages=%d\n", segment_id(seg), mode, lo, hi, *hi_got, skip_mode, *n_pages);
     if (flush_skip == 1) {
         log_printf(5, "END seg=" XIDT " mode=%d lo=" XOT " hi=" XOT " hi_got=" XOT " skip_mode=%d n_pages=%d flush_skip=%d\n", segment_id(seg), mode, lo, hi, *hi_got, skip_mode, *n_pages, flush_skip);
-        tbx_flush_log();
+        tbx_log_flush();
     }
-//tbx_flush_log();
+//tbx_log_flush();
 
     return(skip_mode);
 }
@@ -1701,7 +1701,7 @@ int cache_release_pages(int n_pages, page_handle_t *page_list, int rw_mode)
                 page_list[i].data->ptr = NULL;
                 s->c->write_temp_overflow_used -= s->page_size;
                 log_printf(15, "seg=" XIDT " p->offset=" XOT " COP cleanup used=" XOT " rw_mode=%d usage=%d\n", segment_id(seg), page->offset, s->c->write_temp_overflow_used, rw_mode, page_list[i].data->usage_count);
-                tbx_flush_log();
+                tbx_log_flush();
             }
         }
 
@@ -1769,11 +1769,11 @@ void _cache_ppages_range_print(int ll, cache_partial_page_t *pp)
 
     log_printf(ll, "page_start=" XOT " page_end=" XOT " n_ranges=%d full=%d\n", pp->page_start, pp->page_end, tbx_stack_size(pp->range_stack), pp->flags);
 
-    crng = tbx_get_ele_data(pp->range_stack);
-    cptr = tbx_get_ptr(pp->range_stack);
+    crng = tbx_stack_get_current_data(pp->range_stack);
+    cptr = tbx_stack_get_current_ptr(pp->range_stack);
     tbx_stack_move_to_top(pp->range_stack);
     i=0;
-    while ((rng = tbx_get_ele_data(pp->range_stack)) != NULL) {
+    while ((rng = tbx_stack_get_current_data(pp->range_stack)) != NULL) {
         curr = (rng == crng) ? "CURR" : "";
         log_printf(ll, "  i=%d " XOT " - " XOT " %s\n", i, rng[0], rng[1], curr);
         tbx_stack_move_down(pp->range_stack);
@@ -1795,18 +1795,18 @@ int _cache_ppages_range_collapse(cache_partial_page_t *pp)
     ex_off_t *rng, *trng, hi1;
     int more;
 
-    trng = tbx_get_ele_data(pp->range_stack);  //** This is the range just expanded
+    trng = tbx_stack_get_current_data(pp->range_stack);  //** This is the range just expanded
     hi1 = trng[1]+1;
 
     tbx_stack_move_down(pp->range_stack);
     more = 1;
-    while (((rng = tbx_get_ele_data(pp->range_stack)) != NULL) && (more == 1)) {
+    while (((rng = tbx_stack_get_current_data(pp->range_stack)) != NULL) && (more == 1)) {
         if (hi1 >= rng[0]) { //** Got an overlap so collapse
             if (rng[1] > trng[1]) {
                 trng[1] = rng[1];
                 more = 0;  //** Kick out this is the last range
             }
-            tbx_delete_current(pp->range_stack, 0, 1);
+            tbx_stack_delete_current(pp->range_stack, 0, 1);
         } else {
             more = 0;
         }
@@ -1817,7 +1817,7 @@ int _cache_ppages_range_collapse(cache_partial_page_t *pp)
     //** Check if we have a full page
     if (tbx_stack_size(pp->range_stack) == 1) {
         tbx_stack_move_to_top(pp->range_stack);
-        rng = tbx_get_ele_data(pp->range_stack);
+        rng = tbx_stack_get_current_data(pp->range_stack);
         log_printf(5, "lo=" XOT " gi=" XOT "\n", rng[0], rng[1]);
 
         if ((rng[0] == 0) && (rng[1] == (pp->page_end - pp->page_start))) {
@@ -1863,7 +1863,7 @@ int _cache_ppages_range_merge(segment_t *seg, cache_partial_page_t *pp, ex_off_t
     //** Find the insertion point
     tbx_stack_move_to_top(pp->range_stack);
     prng = NULL;
-    while ((rng = tbx_get_ele_data(pp->range_stack)) != NULL) {
+    while ((rng = tbx_stack_get_current_data(pp->range_stack)) != NULL) {
         if (lo <= rng[0]) break;  //** Got it
         prng = rng;
         tbx_stack_move_down(pp->range_stack);
@@ -1977,14 +1977,14 @@ int _cache_ppages_flush_list(segment_t *seg, data_attr_t *da, tbx_stack_t *pp_li
     //** Cycle through the pages makng the write map for each page
     n_ranges = 0;
     tbx_stack_move_to_top(pp_list);
-    while ((pp = tbx_get_ele_data(pp_list)) != NULL) {
+    while ((pp = tbx_stack_get_current_data(pp_list)) != NULL) {
         log_printf(5, "START ppoff=" XOT " RSTACK=%p size=%d flags=%d\n", pp->page_start, pp->range_stack, tbx_stack_size(pp->range_stack), pp->flags);
-        tbx_flush_log();
+        tbx_log_flush();
 
         n_ranges += (pp->flags == 1) ? 1 : tbx_stack_size(pp->range_stack);
         tbx_stack_move_down(pp_list);
         log_printf(5, "END ppoff=" XOT " RSTACK=%p size=%d full=%d n_ranges=%d\n", pp->page_start, pp->range_stack, tbx_stack_size(pp->range_stack), pp->flags, n_ranges);
-        tbx_flush_log();
+        tbx_log_flush();
     }
 
     //** Fill in the RW op struct
@@ -2002,7 +2002,7 @@ int _cache_ppages_flush_list(segment_t *seg, data_attr_t *da, tbx_stack_t *pp_li
     nbytes = 0;
     slot = 0;
     tbx_stack_move_to_top(pp_list);
-    while ((pp = tbx_get_ele_data(pp_list)) != NULL) {
+    while ((pp = tbx_stack_get_current_data(pp_list)) != NULL) {
         if (pp->flags == 1) {
             iov[slot].iov_base = pp->data;
             iov[slot].iov_len = s->page_size;
@@ -2049,7 +2049,7 @@ int _cache_ppages_flush_list(segment_t *seg, data_attr_t *da, tbx_stack_t *pp_li
     cache_lock(s->c);  //** I had this on the way in
 
     //** Update the ppage_max
-    rng = tbx_sl_last_key(s->partial_pages);
+    rng = tbx_sl_key_last(s->partial_pages);
     if (rng == NULL) {    //** No ppages left
         s->ppage_max = -1;
     } else {  //** Need to find the check the last partial page to determine the max offset
@@ -2060,7 +2060,7 @@ int _cache_ppages_flush_list(segment_t *seg, data_attr_t *da, tbx_stack_t *pp_li
             fprintf(stderr, "ERROR: sid=" XIDT " lost partial page!  Looking for pp->page_start=" XOT "\n", segment_id(seg), *rng);
         } else {
             tbx_stack_move_to_bottom(pp->range_stack);
-            rng = tbx_get_ele_data(pp->range_stack);
+            rng = tbx_stack_get_current_data(pp->range_stack);
             if (rng != NULL) {
                 s->ppage_max = pp->page_start + rng[1];
             }
@@ -2101,7 +2101,7 @@ int _cache_ppages_flush(segment_t *seg, data_attr_t *da)
     it = tbx_sl_iter_search(s->partial_pages, NULL, 0);
     while (tbx_sl_next(&it, (tbx_sl_key_t **)&ppoff, (tbx_sl_data_t **)&pp) == 0) {
         log_printf(5, "ppoff=" XOT " RSTACK=%p size=%d flags=%d\n", pp->page_start, pp->range_stack, tbx_stack_size(pp->range_stack), pp->flags);
-        tbx_flush_log();
+        tbx_log_flush();
         tbx_stack_insert_below(&pp_list, pp);
     }
 
@@ -2130,7 +2130,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
     int do_flush, err, lo_mapped, hi_mapped;
 
     log_printf(5, "START lo=" XOT " hi=" XOT " bpos=" XOT "\n", *lo, *hi, *bpos);
-    tbx_flush_log();
+    tbx_log_flush();
 
     cache_lock(s->c);
     if (s->n_ppages == 0) {
@@ -2203,7 +2203,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
                 log_printf(5, "HI_MAPPED INSERT seg=" XIDT " using pstart=" XOT " pend=" XOT " rlo=%d rhi=" XOT "\n", segment_id(seg), pp->page_start, pp->page_end, 0, nbytes-1);
             } else {   //** Got a read hit so check if the 1st range completely overlaps otherwise flush the page
                 tbx_stack_move_to_top(pp->range_stack);
-                rng = tbx_get_ele_data(pp->range_stack);
+                rng = tbx_stack_get_current_data(pp->range_stack);
                 poff = *hi - pp->page_start;
                 if ((rng[0] == 0) && (rng[1] >= poff)) { //** 1st range overlaps so handle it
                     poff = 0;
@@ -2252,7 +2252,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
                     plo = *lo - pp->page_start;
                     phi = *hi - pp->page_start;
                     tbx_stack_move_to_top(pp->range_stack);
-                    while ((rng = tbx_get_ele_data(pp->range_stack)) != NULL) {
+                    while ((rng = tbx_stack_get_current_data(pp->range_stack)) != NULL) {
                         if ((rng[0] <= plo) && (rng[1] >= plo)) { //** Found the overlapping range
                             if (rng[1] >= phi) { //** we're good so map it
                                 poff = plo;
@@ -2284,7 +2284,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
                     }
                 } else {  //** The lo/hi mapped pages are different so just have to check the last range
                     tbx_stack_move_to_bottom(pp->range_stack);
-                    rng = tbx_get_ele_data(pp->range_stack);
+                    rng = tbx_stack_get_current_data(pp->range_stack);
                     plo = *lo - pp->page_start;
                     if ((rng[0] <= plo) && (rng[1] == s->page_size-1)) {  //** Got a match
                         poff = plo;
@@ -2332,7 +2332,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
         *hi = hi_new;
         *bpos = bpos_new;
         log_printf(5, "END lo=" XOT " hi=" XOT " bpos=" XOT " nhandled=%" PRId64 " n_pages=%" PRId64 "\n", *lo, *hi, *bpos, nhandled, n_pages);
-        tbx_flush_log();
+        tbx_log_flush();
         return((n_pages == nhandled) ? 1 : 0);
     }
 
@@ -2358,7 +2358,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
         *hi = hi_new;
         *bpos = bpos_new;
         log_printf(5, "RECURSE lo=" XOT " hi=" XOT " bpos=" XOT "\n", *lo, *hi, *bpos);
-        tbx_flush_log();
+        tbx_log_flush();
         cache_unlock(s->c);
         return(cache_ppages_handle(seg, da, rw_mode, lo, hi, len, bpos, tbuf));
     }
@@ -2442,7 +2442,7 @@ int cache_ppages_handle(segment_t *seg, data_attr_t *da, int rw_mode, ex_off_t *
     *hi = hi_new;
     *bpos = bpos_new;
     log_printf(5, "END lo=" XOT " hi=" XOT " bpos=" XOT "\n", *lo, *hi, *bpos);
-    tbx_flush_log();
+    tbx_log_flush();
     return((n_pages == nhandled) ? 1 : 0);
 }
 
@@ -2655,7 +2655,7 @@ op_status_t cache_rw_func(void *arg, int id)
         }
 
         log_printf(15, "bottom lo=" XOT " hi=" XOT " progress=%d mode=%d top=%d bottom=%d\n", curr->lo, curr->hi, progress, mode, top_cnt, bottom_cnt);
-        tbx_flush_log();
+        tbx_log_flush();
         free(curr);
     }
 
@@ -2777,7 +2777,7 @@ op_status_t cache_flush_range_func(void *arg, int id)
 
     now = apr_time_now();
     log_printf(1, "COP seg=" XIDT " offset=" XOT " len=" XOT " size=" XOT "\n", segment_id(cop->seg), cop->iov_single.offset, cop->iov_single.len, segment_size(cop->seg));
-    tbx_flush_log();
+    tbx_log_flush();
 
     total_pages = 0;
     lo = cop->iov_single.offset;
@@ -2810,7 +2810,7 @@ op_status_t cache_flush_range_func(void *arg, int id)
 //mode = CACHE_DOBLOCK;  //**QWERTY
         status = cache_dirty_pages_get(cop->seg, mode, curr->lo, curr->hi, &hi_got, page, &n_pages);
         log_printf(1, "seg=" XIDT " processing range: lo=" XOT " hi=" XOT " hi_got=" XOT " mode=%d skip_mode=%d n_pages=%d\n", segment_id(cop->seg), curr->lo, curr->hi, hi_got, mode, status, n_pages);
-        tbx_flush_log();
+        tbx_log_flush();
 
         if (status == 0) {  //** Got some data to process
             progress = 1;  //** Flag that progress was made
@@ -2852,10 +2852,10 @@ op_status_t cache_flush_range_func(void *arg, int id)
     segment_lock(cop->seg);
     //** Remove myself from the stack
     tbx_stack_move_to_top(s->flush_stack);
-    while ((ex_off_t *)tbx_get_ele_data(s->flush_stack) != flush_id) {
+    while ((ex_off_t *)tbx_stack_get_current_data(s->flush_stack) != flush_id) {
         tbx_stack_move_down(s->flush_stack);
     }
-    tbx_delete_current(s->flush_stack, 0, 0);
+    tbx_stack_delete_current(s->flush_stack, 0, 0);
     log_printf(5, "END seg=" XIDT " lo=" XOT " hi=" XOT " flush_id=" XOT " AFTER WAIT\n", segment_id(cop->seg), lo, hi, flush_id[2]);
 
     //** Notify anyone else
@@ -3357,20 +3357,20 @@ int segcache_deserialize_text(segment_t *seg, ex_id_t myid, exnode_exchange_t *e
     snprintf(seggrp, bufsize, "segment-" XIDT, myid);
 
     //** Basic size info
-    s->total_size = tbx_inip_integer_get(fd, seggrp, "used_size", -1);
+    s->total_size = tbx_inip_get_integer(fd, seggrp, "used_size", -1);
 
     //** Load the child
-    id = tbx_inip_integer_get(fd, seggrp, "segment", 0);
+    id = tbx_inip_get_integer(fd, seggrp, "segment", 0);
     if (id == 0) {
         log_printf(0, "ERROR missing child segment tag initial sid=" XIDT " myid=" XIDT "\n",segment_id(seg), myid);
-        tbx_flush_log();
+        tbx_log_flush();
         return (-1);
     }
 
     s->child_seg = load_segment(seg->ess, id, exp);
     if (s->child_seg == NULL) {
         log_printf(0, "ERROR child_seg = NULL initial sid=" XIDT " myid=" XIDT " cid=" XIDT "\n",segment_id(seg), myid, id);
-        tbx_flush_log();
+        tbx_log_flush();
         return(-2);
     }
 
@@ -3378,7 +3378,7 @@ int segcache_deserialize_text(segment_t *seg, ex_id_t myid, exnode_exchange_t *e
     if (s->c) {
         cache_lock(s->c);
         log_printf(5, "CSEG-I Removing seg=" XIDT " nsegs=%d myid=" XIDT "\n", segment_id(seg), tbx_list_key_count(s->c->segments), myid);
-        tbx_flush_log();
+        tbx_log_flush();
         tbx_list_remove(s->c->segments, &(segment_id(seg)), seg);
         s->c->fn.removing_segment(s->c, seg);
         cache_unlock(s->c);
@@ -3391,7 +3391,7 @@ int segcache_deserialize_text(segment_t *seg, ex_id_t myid, exnode_exchange_t *e
     s->qname = strdup(qname);
 
     seg->header.type = SEGMENT_TYPE_CACHE;
-    seg->header.name = tbx_inip_string_get(fd, seggrp, "name", "");
+    seg->header.name = tbx_inip_get_string(fd, seggrp, "name", "");
 
     tbx_atomic_inc(s->child_seg->ref_count);
 
@@ -3436,7 +3436,7 @@ int segcache_deserialize_text(segment_t *seg, ex_id_t myid, exnode_exchange_t *e
     if (s->c != NULL) {
         cache_lock(s->c);
         log_printf(5, "CSEG Inserting seg=" XIDT " nsegs=%d\n", segment_id(seg), tbx_list_key_count(s->c->segments));
-        tbx_flush_log();
+        tbx_log_flush();
         tbx_list_insert(s->c->segments, &(segment_id(seg)), seg);
         s->c->fn.adding_segment(s->c, seg);
         cache_unlock(s->c);
@@ -3483,7 +3483,7 @@ void segcache_destroy(segment_t *seg)
 
     //** Check if it's still in use
     log_printf(2, "segcache_destroy: seg->id=" XIDT " ref_count=%d sptr=%p\n", segment_id(seg), seg->ref_count, seg);
-//tbx_flush_log();
+//tbx_log_flush();
 
 //log_printf(2, "CACHE-PTR seg=" XIDT " s->c=%p\n", segment_id(seg), s->c);
 
@@ -3508,7 +3508,7 @@ void segcache_destroy(segment_t *seg)
         //** Remove it from the cache manager
         cache_lock(s->c);
         log_printf(5, "CSEG Removing seg=" XIDT " nsegs=%d\n", segment_id(seg), tbx_list_key_count(s->c->segments));
-        tbx_flush_log();
+        tbx_log_flush();
         tbx_list_remove(s->c->segments, &(segment_id(seg)), seg);
         cache_unlock(s->c);
 
@@ -3543,7 +3543,7 @@ void segcache_destroy(segment_t *seg)
 
     //** Drop the flush args
     apr_thread_cond_destroy(s->flush_cond);
-    tbx_free_stack(s->flush_stack, 0);
+    tbx_stack_free(s->flush_stack, 0);
 
 //log_printf(0, "After flush/drop seg=" XIDT "\n", segment_id(seg));
     CACHE_PRINT;
@@ -3563,13 +3563,13 @@ void segcache_destroy(segment_t *seg)
     //** and finally the misc stuff
     if (s->n_ppages > 0) {
         for (i=0; i<s->n_ppages; i++) {
-            tbx_free_stack(s->ppage[i].range_stack, 1);
+            tbx_stack_free(s->ppage[i].range_stack, 1);
         }
         free(s->ppages_buffer);
         free(s->ppage);
     }
 
-    tbx_free_stack(s->ppages_unused, 0);
+    tbx_stack_free(s->ppages_unused, 0);
 
     apr_thread_mutex_destroy(seg->lock);
     apr_thread_cond_destroy(seg->cond);
@@ -3648,7 +3648,7 @@ segment_t *segment_cache_create(void *arg)
         cache_lock(s->c);
         CACHE_PRINT;
         log_printf(5, "CSEG-I Inserting seg=" XIDT " nsegs=%d\n", segment_id(seg), tbx_list_key_count(s->c->segments));
-        tbx_flush_log();
+        tbx_log_flush();
         tbx_list_insert(s->c->segments, &(segment_id(seg)), seg);
         s->c->fn.adding_segment(s->c, seg);
         CACHE_PRINT;

--- a/src/lio/segment_file.c
+++ b/src/lio/segment_file.c
@@ -96,7 +96,7 @@ op_status_t segfile_rw_func(void *arg, int id)
     if (fd == NULL) fd = fopen(s->fname, "w+");
 
     log_printf(15, "segfile_rw_func: tid=%d fname=%s n_iov=%d off[0]=" XOT " len[0]=" XOT " mode=%d\n", tbx_atomic_thread_id, s->fname, srw->n_iov, srw->iov[0].offset, srw->iov[0].len, srw->mode);
-    tbx_flush_log();
+    tbx_log_flush();
     tbx_tbuf_var_init(&tbv);
 
     blen = srw->len;
@@ -120,7 +120,7 @@ op_status_t segfile_rw_func(void *arg, int id)
             int ib = blen;
             int inb = nbytes;
             log_printf(15, "segfile_rw_func: tid=%d fname=%s n_iov=%d off[0]=" XOT " len[0]=" XOT " blen=%d nbytes=%d err_cnt=%d\n", tbx_atomic_thread_id, s->fname, srw->n_iov, srw->iov[0].offset, srw->iov[0].len, ib, inb, err_cnt);
-            tbx_flush_log();
+            tbx_log_flush();
 
             if (nbytes > 0) {
                 boff = boff + nbytes;
@@ -141,7 +141,7 @@ op_status_t segfile_rw_func(void *arg, int id)
     }
 
     log_printf(15, "segfile_rw_func: tid=%d fname=%s n_iov=%d off[0]=" XOT " len[0]=" XOT " bleft=" XOT " err_cnt=%d\n", tbx_atomic_thread_id, s->fname, srw->n_iov, srw->iov[0].offset, srw->iov[0].len, bleft, err_cnt);
-    tbx_flush_log();
+    tbx_log_flush();
 //log_printf(15, "segfile_rw_func: buf=%20s\n", (char *)srw->buffer->buf.iov[0].iov_base);
     fclose(fd);
     return(err);
@@ -538,10 +538,10 @@ int segfile_deserialize_text(segment_t *seg, ex_id_t id, exnode_exchange_t *exp)
     s->qname = strdup(qname);
 
     seg->header.type = SEGMENT_TYPE_FILE;
-    seg->header.name = tbx_inip_string_get(fd, seggrp, "name", "");
+    seg->header.name = tbx_inip_get_string(fd, seggrp, "name", "");
 
     //** and the local file name
-    s->fname = tbx_inip_string_get(fd, seggrp, "file", "");
+    s->fname = tbx_inip_get_string(fd, seggrp, "file", "");
 
     if (strcmp(s->fname, "") == 0) {
         s->fname = NULL;

--- a/src/lio/segment_jerasure.c
+++ b/src/lio/segment_jerasure.c
@@ -589,7 +589,7 @@ op_status_t segjerase_inspect_full_func(void *arg, int id)
 
 next:  //** Jump to here if an empty stripe
 
-            if ((tbx_get_info_level(si->fd) > 1) && (tmp != bad_count)) {   //** Print some diag info if needed
+            if ((tbx_stack_get_info_level(si->fd) > 1) && (tmp != bad_count)) {   //** Print some diag info if needed
                 oops = (((repair_errors+unrecoverable_count) > 0) && (fail_quick > 0) && (i== nstripes-1)) ? 1 : 0;
 
                 if ((stripe+i-1 != last_bad) || (memcmp(badmap_last, badmap, sizeof(int)*s->n_devs) != 0)) {
@@ -1992,10 +1992,10 @@ int segjerase_deserialize_text(segment_t *seg, ex_id_t id, exnode_exchange_t *ex
     //** Get the segment header info
     seg->header.id = id;
     seg->header.type = SEGMENT_TYPE_JERASURE;
-    seg->header.name = tbx_inip_string_get(fd, seggrp, "name", "");
+    seg->header.name = tbx_inip_get_string(fd, seggrp, "name", "");
 
     //** Load the child segemnt (should be a LUN segment)
-    id = tbx_inip_integer_get(fd, seggrp, "segment", 0);
+    id = tbx_inip_get_integer(fd, seggrp, "segment", 0);
     if (id == 0) {
         return (-1);
     }
@@ -2008,25 +2008,25 @@ int segjerase_deserialize_text(segment_t *seg, ex_id_t id, exnode_exchange_t *ex
     tbx_atomic_inc(s->child_seg->ref_count);
 
     //** Load the params
-    s->write_errors = tbx_inip_integer_get(fd, seggrp, "write_errors", 0);
+    s->write_errors = tbx_inip_get_integer(fd, seggrp, "write_errors", 0);
     if ((s->paranoid_check == 0) && (s->write_errors > 0)) s->paranoid_check = 1;
 
-    s->magic_cksum = tbx_inip_integer_get(fd, seggrp, "magic_cksum", 0);
+    s->magic_cksum = tbx_inip_get_integer(fd, seggrp, "magic_cksum", 0);
     if (s->magic_cksum == 0) {
         if (segment_size(s->child_seg) == 0) s->magic_cksum = 1;  //** If empty file enable adler32 magic
     }
-    s->n_data_devs = tbx_inip_integer_get(fd, seggrp, "n_data_devs", 6);
-    s->n_parity_devs = tbx_inip_integer_get(fd, seggrp, "n_parity_devs", 3);
+    s->n_data_devs = tbx_inip_get_integer(fd, seggrp, "n_data_devs", 6);
+    s->n_parity_devs = tbx_inip_get_integer(fd, seggrp, "n_parity_devs", 3);
     s->n_devs = s->n_data_devs + s->n_parity_devs;
-    s->w = tbx_inip_integer_get(fd, seggrp, "w", -1);
-    s->max_parity = tbx_inip_integer_get(fd, seggrp, "max_parity", 16*1024*1024);
-    s->chunk_size = tbx_inip_integer_get(fd, seggrp, "chunk_size", 16*1024);
+    s->w = tbx_inip_get_integer(fd, seggrp, "w", -1);
+    s->max_parity = tbx_inip_get_integer(fd, seggrp, "max_parity", 16*1024*1024);
+    s->chunk_size = tbx_inip_get_integer(fd, seggrp, "chunk_size", 16*1024);
     s->stripe_size = s->chunk_size * s->n_devs;
     s->data_size = s->chunk_size * s->n_data_devs;
     s->parity_size = s->chunk_size * s->n_parity_devs;
     s->chunk_size_with_magic = s->chunk_size + JE_MAGIC_SIZE;
     s->stripe_size_with_magic = s->chunk_size_with_magic * s->n_devs;
-    text = tbx_inip_string_get(fd, seggrp, "method", (char *)JE_method[CAUCHY_GOOD]);
+    text = tbx_inip_get_string(fd, seggrp, "method", (char *)JE_method[CAUCHY_GOOD]);
     s->method = et_method_type(text);
     free(text);
     if (s->method < 0) return(-3);

--- a/src/lio/segment_linear.c
+++ b/src/lio/segment_linear.c
@@ -183,7 +183,7 @@ op_status_t _sl_grow(segment_t *seg, data_attr_t *da, ex_off_t new_size_arg, int
     }
 
     log_printf(15, "_sl_grow: sid=" XIDT " before exec gop2=%p\n", segment_id(seg), gop2);
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Ececute it(them)
     if (gop1 == NULL) {
@@ -333,7 +333,7 @@ op_status_t _sl_shrink(segment_t *seg, data_attr_t *da, ex_off_t new_size, int t
         free(b);
     }
 
-    tbx_free_stack(stack, 0);
+    tbx_stack_free(stack, 0);
 
     //** If needed tweak the initial block
     if (start_b != NULL) {
@@ -446,7 +446,7 @@ op_status_t seglin_read_func(void *arg, int id)
 
             log_printf(15, "seglin_read: sid=" XIDT " bid=" XIDT " soff=" XOT " bpos=" XOT " blen=" XOT "\n", segment_id(sr->seg),
                        data_block_id(b->data), start, bpos, blen);
-            tbx_flush_log();
+            tbx_log_flush();
 
             gop = ds_read(b->data->ds, sr->da, ds_get_cap(b->data->ds, b->data->cap, DS_CAP_READ), start, sr->buffer, bpos, blen, sr->timeout);
 
@@ -549,7 +549,7 @@ op_generic_t *seglin_write_op(segment_t *seg, data_attr_t *da, segment_rw_hints_
 
             log_printf(15, "seglin_write_op: sid=" XIDT " bid=" XIDT " soff=" XOT " bpos=" XOT " blen=" XOT " seg_off=" XOT " seg_len=" XOT " seg_end=" XOT "\n", segment_id(seg),
                        data_block_id(b->data), start, bpos, blen, b->seg_offset, b->len, b->seg_end);
-            tbx_flush_log();
+            tbx_log_flush();
 
             gop = ds_write(b->data->ds, da, ds_get_cap(b->data->ds, b->data->cap, DS_CAP_WRITE), start, buffer, bpos, blen, timeout);
 
@@ -1143,32 +1143,32 @@ int seglin_deserialize_text(segment_t *seg, ex_id_t id, exnode_exchange_t *exp)
     //** Get the segment header info
     seg->header.id = id;
     seg->header.type = SEGMENT_TYPE_LINEAR;
-    seg->header.name = tbx_inip_string_get(fd, seggrp, "name", "");
+    seg->header.name = tbx_inip_get_string(fd, seggrp, "name", "");
 
     //** default resource query
-    etext = tbx_inip_string_get(fd, seggrp, "query_default", "");
+    etext = tbx_inip_get_string(fd, seggrp, "query_default", "");
     text = tbx_stk_unescape_text('\\', etext);
     s->rsq = rs_query_parse(s->rs, text);
     free(text);
     free(etext);
-    s->n_rid_default = tbx_inip_integer_get(fd, seggrp, "n_rid_default", 2);
+    s->n_rid_default = tbx_inip_get_integer(fd, seggrp, "n_rid_default", 2);
 
     //** Basic size info
-    s->max_block_size = tbx_inip_integer_get(fd, seggrp, "max_block_size", 10*1024*1024);
-    s->excess_block_size = tbx_inip_integer_get(fd, seggrp, "excess_block_size", s->max_block_size/4);
-    s->total_size = tbx_inip_integer_get(fd, seggrp, "max_size", 0);
-    s->used_size = tbx_inip_integer_get(fd, seggrp, "used_size", 0);
+    s->max_block_size = tbx_inip_get_integer(fd, seggrp, "max_block_size", 10*1024*1024);
+    s->excess_block_size = tbx_inip_get_integer(fd, seggrp, "excess_block_size", s->max_block_size/4);
+    s->total_size = tbx_inip_get_integer(fd, seggrp, "max_size", 0);
+    s->used_size = tbx_inip_get_integer(fd, seggrp, "used_size", 0);
 
     //** Cycle through the blocks storing both the segment block information and also the cap blocks
     g = tbx_inip_group_find(fd, seggrp);
     ele = tbx_inip_ele_first(g);
     while (ele != NULL) {
-        key = tbx_inip_ele_key_get(ele);
+        key = tbx_inip_ele_get_key(ele);
         if (strcmp(key, "block") == 0) {
             tbx_type_malloc_clear(b, seglin_slot_t, 1);
 
             //** Parse the segment line
-            value = tbx_inip_ele_value_get(ele);
+            value = tbx_inip_ele_get_value(ele);
             token = strdup(value);
             sscanf(tbx_stk_escape_string_token(token, ":", '\\', 0, &bstate, &fin), XIDT, &id);
             sscanf(tbx_stk_escape_string_token(NULL, ":", '\\', 0, &bstate, &fin), XOT, &(b->seg_offset));

--- a/src/lio/segment_log.c
+++ b/src/lio/segment_log.c
@@ -709,7 +709,7 @@ op_status_t seglog_clone_func(void *arg, int id)
 
     if (err != OP_STATE_SUCCESS) {
         log_printf(1, "Error during intial cloning phase:  src=" XIDT "\n", segment_id(slc->sseg));
-        if (stack != NULL) tbx_free_stack(stack, 1);
+        if (stack != NULL) tbx_stack_free(stack, 1);
         opque_free(q, OP_DESTROY);
         return(op_failure_status);
     }
@@ -732,7 +732,7 @@ op_status_t seglog_clone_func(void *arg, int id)
         rlen = 0;
         q1 = q;
         q2 = new_opque();
-        while ((clog = (slog_changes_t *)tbx_get_ele_data(stack)) != NULL) {
+        while ((clog = (slog_changes_t *)tbx_stack_get_current_data(stack)) != NULL) {
             pos = 0;
             rpos = clog->seg_offset;
             wpos = clog->lo;
@@ -756,7 +756,7 @@ op_status_t seglog_clone_func(void *arg, int id)
                     opque_free(q1, OP_DESTROY);  //** Free the space
                     if (err != OP_STATE_SUCCESS) {
                         log_printf(1, "Error during log copy phase:  src=" XIDT "\n", segment_id(slc->sseg));
-                        tbx_free_stack(stack, 1);
+                        tbx_stack_free(stack, 1);
                         free(buffer);
                         opque_free(q2, OP_DESTROY);
                         return(op_failure_status);
@@ -805,7 +805,7 @@ op_status_t seglog_clone_func(void *arg, int id)
     }
 
     //** Clean up
-    if (stack != NULL) tbx_free_stack(stack, 1);
+    if (stack != NULL) tbx_stack_free(stack, 1);
     if (buffer != NULL) free(buffer);
     if (q2 == NULL) {
         opque_free(q, OP_DESTROY);
@@ -1156,22 +1156,22 @@ int seglog_deserialize_text(segment_t *seg, ex_id_t id, exnode_exchange_t *exp)
     //** Get the segment header info
     seg->header.id = id;
     seg->header.type = SEGMENT_TYPE_LOG;
-    seg->header.name = tbx_inip_string_get(fd, seggrp, "name", "");
+    seg->header.name = tbx_inip_get_string(fd, seggrp, "name", "");
 
     //** Load the child segments
-    id = tbx_inip_integer_get(fd, seggrp, "log", 0);
+    id = tbx_inip_get_integer(fd, seggrp, "log", 0);
     if (id == 0) return (-1);
     s->table_seg = load_segment(seg->ess, id, exp);
     if (s->table_seg == NULL) return(-2);
     tbx_atomic_inc(s->table_seg->ref_count);
 
-    id = tbx_inip_integer_get(fd, seggrp, "data", 0);
+    id = tbx_inip_get_integer(fd, seggrp, "data", 0);
     if (id == 0) return (-1);
     s->data_seg = load_segment(seg->ess, id, exp);
     if (s->data_seg == NULL) return(-2);
     tbx_atomic_inc(s->data_seg->ref_count);
 
-    id = tbx_inip_integer_get(fd, seggrp, "base", 0);
+    id = tbx_inip_get_integer(fd, seggrp, "base", 0);
     if (id == 0) return (-1);
     s->base_seg = load_segment(seg->ess, id, exp);
     if (s->base_seg == NULL) return(-2);

--- a/src/lio/trace.c
+++ b/src/lio/trace.c
@@ -107,11 +107,11 @@ trace_t *trace_load(service_manager_t *exs, exnode_t *tex, data_attr_t *da, int 
 //  char *template;
     segment_t *tseg;
 
-    tfd = tbx_inip_file_read(fname);
+    tfd = tbx_inip_read_file(fname);
 
-    n_files = tbx_inip_integer_get(tfd, "trace", "n_files", -1);
-    n_ops = tbx_inip_integer_get(tfd, "trace", "n_ops", -1);
-    trace_fname = tbx_inip_string_get(tfd, "trace", "trace", "");
+    n_files = tbx_inip_get_integer(tfd, "trace", "n_files", -1);
+    n_ops = tbx_inip_get_integer(tfd, "trace", "n_ops", -1);
+    trace_fname = tbx_inip_get_string(tfd, "trace", "trace", "");
 
     assert(n_files > 0);
     assert(n_ops > 0);

--- a/src/lio/trace.c
+++ b/src/lio/trace.c
@@ -107,7 +107,7 @@ trace_t *trace_load(service_manager_t *exs, exnode_t *tex, data_attr_t *da, int 
 //  char *template;
     segment_t *tseg;
 
-    tfd = tbx_inip_read_file(fname);
+    tfd = tbx_inip_file_read(fname);
 
     n_files = tbx_inip_get_integer(tfd, "trace", "n_files", -1);
     n_ops = tbx_inip_get_integer(tfd, "trace", "n_ops", -1);

--- a/src/lio/view_layout.c
+++ b/src/lio/view_layout.c
@@ -171,7 +171,7 @@ int vl_deserialize_text(view_t *v, ex_id_t id, exnode_exchange_t *exp)
     tbx_inip_file_t *fd;
 
     //** Parse the ini text
-    fd = tbx_inip_read_string(exp->text);
+    fd = tbx_inip_string_read(exp->text);
 
     //** Make the layout section name
     snprintf(grp, bufsize, "view-" XIDT, id);

--- a/src/lio/view_layout.c
+++ b/src/lio/view_layout.c
@@ -171,7 +171,7 @@ int vl_deserialize_text(view_t *v, ex_id_t id, exnode_exchange_t *exp)
     tbx_inip_file_t *fd;
 
     //** Parse the ini text
-    fd = tbx_inip_string_read(exp->text);
+    fd = tbx_inip_read_string(exp->text);
 
     //** Make the layout section name
     snprintf(grp, bufsize, "view-" XIDT, id);
@@ -179,7 +179,7 @@ int vl_deserialize_text(view_t *v, ex_id_t id, exnode_exchange_t *exp)
     //** Get the header info
     v->header.id = id;
     v->header.type = VIEW_TYPE_LAYOUT;
-    v->header.name = tbx_inip_string_get(fd, grp, "name", "");
+    v->header.name = tbx_inip_get_string(fd, grp, "name", "");
 
     //** and the layout to use
     lay_id = inip_get_unsigned_integer(fd, grp, "layout", 0);

--- a/src/toolbox/debug.h
+++ b/src/toolbox/debug.h
@@ -32,7 +32,7 @@
 #define debug_code(a) a
 #define debug_printf(n, ...) log_printf(n, __VA_ARGS__)
 #define set_debug_level(n) tbx_set_log_level(n)
-#define flush_debug() tbx_flush_log()
+#define flush_debug() tbx_log_flush()
 #define debug_level() tbx_log_level()
 
 #else

--- a/src/toolbox/iniparse.c
+++ b/src/toolbox/iniparse.c
@@ -50,11 +50,11 @@ tbx_inip_element_t * tbx_inip_ele_first(tbx_inip_group_t *group) {
     return group->list;
 }
 
-char *tbx_inip_ele_key_get(tbx_inip_element_t *ele) {
+char *tbx_inip_ele_get_key(tbx_inip_element_t *ele) {
     return ((ele) == NULL) ? NULL : (ele)->key;
 }
 
-char *tbx_inip_ele_value_get(tbx_inip_element_t *ele) {
+char *tbx_inip_ele_get_value(tbx_inip_element_t *ele) {
     return ((ele) == NULL) ? NULL : (ele)->value;
 }
 
@@ -70,7 +70,7 @@ char *tbx_inip_group_get(tbx_inip_group_t *g) {
 tbx_inip_group_t *tbx_inip_group_next(tbx_inip_group_t *g) {
     return ((g) == NULL) ? NULL : (g)->next;
 }
-int tbx_inip_n_groups(tbx_inip_file_t *inip) {
+int tbx_inip_group_count(tbx_inip_file_t *inip) {
     return inip->n_groups;
 }
 void tbx_inip_group_free(tbx_inip_group_t *g) {
@@ -98,7 +98,7 @@ FILE *bfile_fopen(tbx_stack_t *include_paths, char *fname)
 
     //** Relative path so cycle through the prefixes
     tbx_stack_move_to_top(include_paths);
-    while ((path = tbx_get_ele_data(include_paths)) != NULL) {
+    while ((path = tbx_stack_get_current_data(include_paths)) != NULL) {
         snprintf(fullpath, BUFMAX, "%s/%s", path, fname);
         fd = fopen(fullpath, "r");
         log_printf(15, "checking path=%s fname=%s fullpath=%s fd=%p\n", path, fname, fullpath, fd);
@@ -356,7 +356,7 @@ tbx_inip_element_t *_find_key(tbx_inip_group_t *group, const char *name)
 //  inip_find_key - Scans the group for the given key and returns the value
 //***********************************************************************
 
-char *tbx_inip_key_find(tbx_inip_group_t *group, const char *name)
+char *tbx_inip_find_key(tbx_inip_group_t *group, const char *name)
 {
     tbx_inip_element_t *ele;
 
@@ -412,7 +412,7 @@ tbx_inip_element_t *_find_group_key(tbx_inip_file_t *inip, const char *group_nam
 // inip_get_* - Routines for getting group/key values
 //***********************************************************************
 
-int64_t tbx_inip_integer_get(tbx_inip_file_t *inip, const char *group, const char *key, int64_t def)
+int64_t tbx_inip_get_integer(tbx_inip_file_t *inip, const char *group, const char *key, int64_t def)
 {
     tbx_inip_element_t *ele = _find_group_key(inip, group, key);
     if (ele == NULL) return(def);
@@ -432,7 +432,7 @@ uint64_t inip_get_unsigned_integer(tbx_inip_file_t *inip, const char *group, con
 
 //***********************************************************************
 
-double tbx_inip_double_get(tbx_inip_file_t *inip, const char *group, const char *key, double def)
+double tbx_inip_get_double(tbx_inip_file_t *inip, const char *group, const char *key, double def)
 {
     tbx_inip_element_t *ele = _find_group_key(inip, group, key);
     if (ele == NULL) return(def);
@@ -442,7 +442,7 @@ double tbx_inip_double_get(tbx_inip_file_t *inip, const char *group, const char 
 
 //***********************************************************************
 
-char *tbx_inip_string_get(tbx_inip_file_t *inip, const char *group, const char *key, char *def)
+char *tbx_inip_get_string(tbx_inip_file_t *inip, const char *group, const char *key, char *def)
 {
     char *value = def;
     tbx_inip_element_t *ele = _find_group_key(inip, group, key);
@@ -505,8 +505,8 @@ tbx_inip_file_t *inip_read_fd(FILE *fd)
         free(entry);
     }
 
-    tbx_free_stack(bfd.stack, 1);
-    tbx_free_stack(bfd.include_paths, 1);
+    tbx_stack_free(bfd.stack, 1);
+    tbx_stack_free(bfd.include_paths, 1);
 
     return(inip);
 }
@@ -515,7 +515,7 @@ tbx_inip_file_t *inip_read_fd(FILE *fd)
 //  inip_read - Reads a .ini file
 //***********************************************************************
 
-tbx_inip_file_t *tbx_inip_file_read(const char *fname)
+tbx_inip_file_t *tbx_inip_read_file(const char *fname)
 {
     FILE *fd;
 
@@ -537,7 +537,7 @@ tbx_inip_file_t *tbx_inip_file_read(const char *fname)
 //  inip_read_text - Converts a character array into a .ini file
 //***********************************************************************
 
-tbx_inip_file_t *tbx_inip_string_read(const char *text)
+tbx_inip_file_t *tbx_inip_read_string(const char *text)
 {
     FILE *fd = tmpfile();
     fprintf(fd, "%s\n", text);

--- a/src/toolbox/iniparse.c
+++ b/src/toolbox/iniparse.c
@@ -515,7 +515,7 @@ tbx_inip_file_t *inip_read_fd(FILE *fd)
 //  inip_read - Reads a .ini file
 //***********************************************************************
 
-tbx_inip_file_t *tbx_inip_read_file(const char *fname)
+tbx_inip_file_t *tbx_inip_file_read(const char *fname)
 {
     FILE *fd;
 
@@ -537,7 +537,7 @@ tbx_inip_file_t *tbx_inip_read_file(const char *fname)
 //  inip_read_text - Converts a character array into a .ini file
 //***********************************************************************
 
-tbx_inip_file_t *tbx_inip_read_string(const char *text)
+tbx_inip_file_t *tbx_inip_string_read(const char *text)
 {
     FILE *fd = tmpfile();
     fprintf(fd, "%s\n", text);

--- a/src/toolbox/interval_skiplist.c
+++ b/src/toolbox/interval_skiplist.c
@@ -207,7 +207,7 @@ tbx_sl_key_t *tbx_isl_key_first(tbx_isl_t *isl)
 
 tbx_sl_key_t *tbx_isl_key_last(tbx_isl_t *isl)
 {
-    return(tbx_sl_last_key(isl->sl));
+    return(tbx_sl_key_last(isl->sl));
 }
 
 //*********************************************************************************
@@ -224,8 +224,8 @@ tbx_isl_t *tbx_isl_new_full(int maxlevels, double p,
     assert(isl != NULL);
 
     isl->n_intervals = 0;
-    isl->data_free = (data_free == NULL) ? tbx_sl_no_data_free : data_free;
-    isl->sl = tbx_sl_new_full(maxlevels, p, 1, compare, dup, key_free, tbx_sl_no_data_free);
+    isl->data_free = (data_free == NULL) ? tbx_sl_free_no_data : data_free;
+    isl->sl = tbx_sl_new_full(maxlevels, p, 1, compare, dup, key_free, tbx_sl_free_no_data);
 
     return(isl);
 }
@@ -409,7 +409,7 @@ int tbx_isl_remove(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_da
             sn2 = sn->next[i];
             if (sn2 != NULL) {
                 cmp = isl->sl->compare->fn(isl->sl->compare->arg, sn2->key, hi);
-//log_printf(15, "remove_interval_skiplist: level=%d cmp=%d\n", i, cmp);  tbx_flush_log();
+//log_printf(15, "remove_interval_skiplist: level=%d cmp=%d\n", i, cmp);  tbx_log_flush();
                 if (cmp < 1) {
                     j = i;
                     remove_isl_data(isl, &(((tbx_isl_node_t *)(sn->ele.data))->edge[j]), data);
@@ -420,20 +420,20 @@ int tbx_isl_remove(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_da
         sn = sn->next[i];  //** Jump to the next element
     }
 
-//log_printf(15, "remove_interval_skiplist: AFTER LOOP\n");  tbx_flush_log();
+//log_printf(15, "remove_interval_skiplist: AFTER LOOP\n");  tbx_log_flush();
 
     //** Now check if we remove the end points
     isln = (tbx_isl_node_t *)(sn->ele.data);
     isln->n_end--;
 
-//log_printf(15, "remove_interval_skiplist: aaaaaaa err=%d\n", err);  tbx_flush_log();
+//log_printf(15, "remove_interval_skiplist: aaaaaaa err=%d\n", err);  tbx_log_flush();
 
     if (isl_node_is_empty(isln, sn->level) == 1) {
         remove_isl_node(sn->level, isln);
         tbx_sl_remove(isl->sl, hi, NULL);
     }
 
-//log_printf(15, "remove_interval_skiplist: bbbbbbbbb\n");  tbx_flush_log();
+//log_printf(15, "remove_interval_skiplist: bbbbbbbbb\n");  tbx_log_flush();
 
     if (sn != sn_lo) {     //** Remove the beginning if needed
        isln = (tbx_isl_node_t *)(sn_lo->ele.data);
@@ -442,12 +442,12 @@ int tbx_isl_remove(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_da
            tbx_sl_remove(isl->sl, lo, NULL);
        }
     }
-//log_printf(15, "remove_interval_skiplist: before data free\n");  tbx_flush_log();
+//log_printf(15, "remove_interval_skiplist: before data free\n");  tbx_log_flush();
 
     //** Lastly free the data
     isl->data_free(data);
 
-//log_printf(15, "remove_interval_skiplist: after data free\n");  tbx_flush_log();
+//log_printf(15, "remove_interval_skiplist: after data free\n");  tbx_log_flush();
 
     return(err);
 }
@@ -509,7 +509,7 @@ tbx_sl_data_t *tbx_isl_next(tbx_isl_iter_t *it)
 
     if (it->finished == 1) return(NULL);
 
-//log_printf(15, "next_interval_skiplist: START ptr_level=%d mode=%d\n", it->ptr_level, it->mode); tbx_flush_log();
+//log_printf(15, "next_interval_skiplist: START ptr_level=%d mode=%d\n", it->ptr_level, it->mode); tbx_log_flush();
 
     if (it->ele != NULL) {  //** Got a match on the current chain
         data = it->ele->data;
@@ -521,7 +521,7 @@ tbx_sl_data_t *tbx_isl_next(tbx_isl_iter_t *it)
     if (it->ptr_level > -1) {  //** Need to scan down the ptr list
         for (i=it->ptr_level; i>-1; i--) {
             if (it->ptr[i] != NULL) {
-//log_printf(15, "next_interval_skiplist: ptr_level=%d i=%d\n", it->ptr_level, i); tbx_flush_log();
+//log_printf(15, "next_interval_skiplist: ptr_level=%d i=%d\n", it->ptr_level, i); tbx_log_flush();
                 isln = (tbx_isl_node_t *)(it->ptr[i]->ele.data);
                 if (isln != NULL) {
                     if (isln->edge[i] != NULL) {
@@ -553,7 +553,7 @@ tbx_sl_data_t *tbx_isl_next(tbx_isl_iter_t *it)
             for (i=it->mode; i<2;  i++) {
                 if (i == 0) {  //** Check if we handle the point list next
                     if (isln->point != NULL) {
-//log_printf(15, "next_interval_skiplist: POINT ptr_level=%d mode=%d i=%d\n", it->ptr_level, it->mode, i); tbx_flush_log();
+//log_printf(15, "next_interval_skiplist: POINT ptr_level=%d mode=%d i=%d\n", it->ptr_level, it->mode, i); tbx_log_flush();
                         it->ele = isln->point;
                         data = it->ele->data;
                         it->ele = it->ele->next;
@@ -563,7 +563,7 @@ tbx_sl_data_t *tbx_isl_next(tbx_isl_iter_t *it)
                     }
                 } else if (i == 1) {   //** or the start list
                     if (isln->start != NULL) {
-//log_printf(15, "next_interval_skiplist: START ptr_level=%d mode=%d i=%d\n", it->ptr_level, it->mode, i); tbx_flush_log();
+//log_printf(15, "next_interval_skiplist: START ptr_level=%d mode=%d i=%d\n", it->ptr_level, it->mode, i); tbx_log_flush();
                         it->ele = isln->start;
                         data = it->ele->data;
                         it->ele = it->ele->next;

--- a/src/toolbox/isl_test.c
+++ b/src/toolbox/isl_test.c
@@ -127,18 +127,18 @@ int main(int argc, char **argv)
                 printf("    %d: %d .. %d\n", j, d->lo, d->hi);
             }
             fflush(stdout);
-            tbx_flush_log();
+            tbx_log_flush();
         }
 
         printf("----manual matches=%d\n", k);
         fflush(stdout);
-        tbx_flush_log();
+        tbx_log_flush();
 
         it = tbx_isl_iter_search(isl, (tbx_sl_key_t *)&lo, (tbx_sl_key_t *)&hi);
-//    printf("    after iter creation\n"); fflush(stdout); tbx_flush_log();
+//    printf("    after iter creation\n"); fflush(stdout); tbx_log_flush();
         n = 0;
         d = tbx_isl_next(&it);
-//    printf("    after initial next\n"); fflush(stdout); tbx_flush_log();
+//    printf("    after initial next\n"); fflush(stdout); tbx_log_flush();
         while (d != NULL) {
             n++;
             printf("    %d: %d .. %d\n", d->index, d->lo, d->hi);
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
                 printf("----------Error!  Found incorrect match!\n");
             }
             fflush(stdout);
-            tbx_flush_log();
+            tbx_log_flush();
 
             d = tbx_isl_next(&it);
         }
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
 
         printf("----iter matches=%d\n", n);
         fflush(stdout);
-        tbx_flush_log();
+        tbx_log_flush();
 
         if (n != k) {
             printf("----------Error mismatch match count k=%d n=%d\n", k, n);
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
     tbx_isl_del(isl);
     fflush(stdout);
-    tbx_flush_log();
+    tbx_log_flush();
 
     free(data_list);
 

--- a/src/toolbox/list.h
+++ b/src/toolbox/list.h
@@ -36,13 +36,13 @@ typedef tbx_sl_iter_t tbx_list_iter_t;
 #define list_string_descending_compare tbx_sl_compare_strcmp_descending
 #define list_compare_ptr skiplist_compare_ptr
 #define list_compare_int tbx_sl_compare_int
-#define tbx_list_no_key_free tbx_sl_no_key_free
+#define tbx_list_no_key_free tbx_sl_free_no_key
 
 #define list_lock(a) apr_thread_mutex_lock((a)->lock)
 #define list_unlock(a) apr_thread_mutex_unlock((a)->lock)
 #define list_ele_count(a) (a)->n_ele
 
-#define list_last_key(a) tbx_sl_last_key(a)
+#define list_last_key(a) tbx_sl_key_last(a)
 
 #define list_find_key_compare(sl, ptr, key, compare) find_key_compare(sl, ptr, key, compare)
 #define list_find_key(sl, ptr, key) find_key_compare(sl, ptr, key, (sl)->compare)

--- a/src/toolbox/log.c
+++ b/src/toolbox/log.c
@@ -179,7 +179,7 @@ void tbx_mlog_load(char *fname, char *output_override, int log_level_override)
     group_level = "log_level";
 
     //** Open the file
-    fd = tbx_inip_read_file(fname);
+    fd = tbx_inip_file_read(fname);
     if (fd == NULL) {
         log_printf(0, "Error loading module definitions!  fname=%s\n", fname);
         return;

--- a/src/toolbox/log.c
+++ b/src/toolbox/log.c
@@ -30,7 +30,7 @@
 #include "tbx/type_malloc.h"
 #include "log.h"
 
-TBX_API int tbx_get_info_level(tbx_log_fd_t *fd) {
+TBX_API int tbx_stack_get_info_level(tbx_log_fd_t *fd) {
     return fd->level;
 }
 
@@ -67,7 +67,7 @@ void _log_init()
 // _open_log - Opens the log file for access
 //***************************************************************
 
-void tbx_open_log(char *fname, int dolock)
+void tbx_log_open(char *fname, int dolock)
 {
     if (dolock == 1) {
         if (_log_lock == NULL) _log_init();
@@ -137,7 +137,7 @@ int tbx_mlog_printf(int suppress_header, int module_index, int level, const char
     _log_currsize += n;
     if (_log_currsize > _log_maxsize) {
         if (_log_special==0) {
-            tbx_open_log(NULL, 0);
+            tbx_log_open(NULL, 0);
         }
         _log_currsize = 0;
     }
@@ -150,7 +150,7 @@ int tbx_mlog_printf(int suppress_header, int module_index, int level, const char
 // flush_log - Flushes the log file
 //***************************************************************
 
-void tbx_flush_log()
+void tbx_log_flush()
 {
     if (_log_lock == NULL) _log_init();
 
@@ -179,19 +179,19 @@ void tbx_mlog_load(char *fname, char *output_override, int log_level_override)
     group_level = "log_level";
 
     //** Open the file
-    fd = tbx_inip_file_read(fname);
+    fd = tbx_inip_read_file(fname);
     if (fd == NULL) {
         log_printf(0, "Error loading module definitions!  fname=%s\n", fname);
         return;
     }
 
-    default_level = tbx_inip_integer_get(fd, group_level, "default", 0);
-    _log_level = (log_level_override > -10) ? log_level_override : tbx_inip_integer_get(fd, group_level, "start_level", 0);
+    default_level = tbx_inip_get_integer(fd, group_level, "default", 0);
+    _log_level = (log_level_override > -10) ? log_level_override : tbx_inip_get_integer(fd, group_level, "start_level", 0);
     for (n=0; n<_mlog_size; n++) _mlog_table[n] = default_level;
-    logname = (output_override == NULL) ? tbx_inip_string_get(fd, group_level, "output", "stdout") : strdup(output_override);
+    logname = (output_override == NULL) ? tbx_inip_get_string(fd, group_level, "output", "stdout") : strdup(output_override);
     open_log(logname);
     free(logname);
-    _log_maxsize = tbx_inip_integer_get(fd, group_level, "size", 100*1024*1024);
+    _log_maxsize = tbx_inip_get_integer(fd, group_level, "size", 100*1024*1024);
 
     //** Load the mappings
     g = tbx_inip_group_find(fd, group_index);
@@ -203,14 +203,14 @@ void tbx_mlog_load(char *fname, char *output_override, int log_level_override)
 
     ele = tbx_inip_ele_first(g);
     while (ele != NULL) {
-        name = tbx_inip_ele_key_get(ele);
-        value = tbx_inip_ele_value_get(ele);
+        name = tbx_inip_ele_get_key(ele);
+        value = tbx_inip_ele_get_value(ele);
 
         n = (value != NULL) ? atoi(value) : -1;
 
         if ((n>=0) && (n<_mlog_size)) {
             _mlog_file_table[n] = strdup(name);
-            _mlog_table[n] = tbx_inip_integer_get(fd, group_level, name, _mlog_table[n]);
+            _mlog_table[n] = tbx_inip_get_integer(fd, group_level, name, _mlog_table[n]);
 //printf("mlog_load: mi=%d key=%s val=%d\n", n, name, _mlog_table[n]);
         } else {
             log_printf(0, "Invalid index: %s=%d  should be between 0..%d!  Skipping option\n", name, n, _mlog_size);

--- a/src/toolbox/log.h
+++ b/src/toolbox/log.h
@@ -72,7 +72,7 @@ void _close_log();
 #define close_log()  _close_log()
 #define log_fd()     _log_fd
 
-#define open_log(fname) tbx_open_log(fname, 1)
+#define open_log(fname) tbx_log_open(fname, 1)
 
 #define assign_log_fd(fd) _log_fd = fd
 
@@ -85,7 +85,7 @@ void _close_log();
 #define log_fd()     stdout
 #define truncate_log()
 #define assign_log_fd(fd)
-#define tbx_flush_log()
+#define tbx_log_flush()
 #define log_printf(n, ...)
 #define tbx_mlog_printf(mi, n, ...)
 

--- a/src/toolbox/net_sock.c
+++ b/src/toolbox/net_sock.c
@@ -125,7 +125,7 @@ int sock_io_wait(tbx_net_sock_t *sock, tbx_ns_timeout_t tm, int mode)
 
     apr_time_t start = apr_time_now();
     double ddt;
-//log_printf(10, "sock_io_wait: START tm=" TT " mode=%d\n", tm, mode);  tbx_flush_log();
+//log_printf(10, "sock_io_wait: START tm=" TT " mode=%d\n", tm, mode);  tbx_log_flush();
 
     dt = tm / 1000;
     if (dt == 0) dt = 1;
@@ -221,7 +221,7 @@ apr_size_t my_write(tbx_net_sock_t *sock, tbx_tbuf_t *buf, apr_size_t bpos, apr_
 //leni=len;
 //len2 = tbv.nbytes;
 //ni=tbv.n_iov;
-//log_printf(15, "s->fd=%d requested=%d got tbv.nbytes=%d tbv.n_iov=%d\n", s->fd, leni, len2, ni); tbx_flush_log();
+//log_printf(15, "s->fd=%d requested=%d got tbv.nbytes=%d tbv.n_iov=%d\n", s->fd, leni, len2, ni); tbx_log_flush();
         if (tbv.n_iov > IOV_MAX) tbv.n_iov = IOV_MAX;  //** Make sure we don't have to many entries
         n = writev(s->fd, tbv.buffer, tbv.n_iov);
         leni=tbv.buffer->iov_len;
@@ -419,7 +419,7 @@ int sock_connect(net_sock_t *nsock, const char *hostname, int port, tbx_ns_timeo
     }
 
     err = apr_socket_connect(sock->fd, sock->sa);
-//log_printf(0, "sock_connect: apr_socket_connect: err=%d\n", err); tbx_flush_log();
+//log_printf(0, "sock_connect: apr_socket_connect: err=%d\n", err); tbx_log_flush();
 
     //** Set a default timeout
     tbx_ns_timeout_set(&tm, 0, SOCK_DEFAULT_TIMEOUT);
@@ -591,7 +591,7 @@ void tbx_ns_sock_config(tbx_ns_t *ns, int tcpsize)
     int err = apr_pool_create(&(sock->mpool), NULL);
     if (err != APR_SUCCESS) {
         log_printf(0, "ns_config_sock:  apr_pool_crete error = %d\n", err);
-        tbx_flush_log();
+        tbx_log_flush();
         assert(err == APR_SUCCESS);
     }
 

--- a/src/toolbox/network.c
+++ b/src/toolbox/network.c
@@ -221,7 +221,7 @@ int tbx_ns_chksum_read_flush(tbx_ns_t *ns)
 
     log_printf(15, "ns_read_chksum_flush: Reading chksum!  ns=%d type=%d bleft=" I64T " bsize=" I64T " state=%d\n",
                tbx_ns_getid(ns), tbx_chksum_type(&(ns->read_chksum.chksum)), ns->read_chksum.bytesleft, ns->read_chksum.blocksize, ns_read_chksum_state(ns));
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (ns_read_chksum_state(ns) == 0) return(0);
     if (ns->read_chksum.bytesleft == ns->read_chksum.blocksize) return(0);  //** Nothing to do
@@ -236,7 +236,7 @@ int tbx_ns_chksum_read_flush(tbx_ns_t *ns)
     ns->read_chksum.is_running = 1;
 
     log_printf(15, "ns_read_chksum_flush: Finished reading chksum!  ns=%d\n", tbx_ns_getid(ns));
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (err != 0) {
         log_printf(10, "ns_read_chksum_flush: ns=%d Error reading chksum! error=%d\n", tbx_ns_getid(ns), err);
@@ -245,7 +245,7 @@ int tbx_ns_chksum_read_flush(tbx_ns_t *ns)
 
     tbx_chksum_get(&(ns->read_chksum.chksum), CHKSUM_DIGEST_HEX, chksum_value);
     log_printf(15, "ns_read_chksum_flush: after tbx_chksum_get!  ns=%d\n", tbx_ns_getid(ns));
-    tbx_flush_log();
+    tbx_log_flush();
     err = (strncmp(chksum_value, ns_value, n) == 0) ? 0 : 1;
 
     log_printf(15, "ns_read_chksum_flush: ns=%d     ns_value=%s  cmp=%d\n", tbx_ns_getid(ns), ns_value, err);
@@ -257,7 +257,7 @@ int tbx_ns_chksum_read_flush(tbx_ns_t *ns)
     }
 
     log_printf(15, "ns_read_chksum_flush: end of routine!  ns=%d\n err=%d", tbx_ns_getid(ns), err);
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(err);
 }
@@ -274,7 +274,7 @@ int tbx_ns_chksum_write_flush(tbx_ns_t *ns)
 
     log_printf(15, "ns_write_chksum_flush: injecting chksum!  ns=%d type=%d bytesleft=" I64T " bsize=" I64T "\n",
                tbx_ns_getid(ns), tbx_chksum_type(&(ns->write_chksum.chksum)), ns->write_chksum.bytesleft, ns->write_chksum.blocksize);
-    tbx_flush_log();
+    tbx_log_flush();
 
     if (ns_write_chksum_state(ns) == 0) return(0);
     if (ns->write_chksum.bytesleft == ns->write_chksum.blocksize) return(0);  //** Nothing to do
@@ -295,7 +295,7 @@ int tbx_ns_chksum_write_flush(tbx_ns_t *ns)
     chksum_value[n] = '\0';
     log_printf(15, "ns_write_chksum_flush: ns=%d chksum_value=%s\n", tbx_ns_getid(ns), chksum_value);
     log_printf(15, "ns_write_chksum_flush: end of routine!  ns=%d\n err=%d", tbx_ns_getid(ns), err);
-    tbx_flush_log();
+    tbx_log_flush();
 
     return(err);
 }
@@ -590,20 +590,20 @@ void close_server_port(tbx_ns_monitor_t *nm)
     apr_thread_mutex_lock(nm->lock);
     nm->shutdown_request = 1;
     log_printf(15, "close_server_port: port=%d Before cond_signal\n", nm->port);
-    tbx_flush_log();
+    tbx_log_flush();
     apr_thread_cond_signal(nm->cond);
     log_printf(15, "close_server_port: port=%d After cond_signal\n", nm->port);
-    tbx_flush_log();
+    tbx_log_flush();
     apr_thread_mutex_unlock(nm->lock);
 
     log_printf(15, "close_server_port: port=%d After unlock\n", nm->port);
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Wait until the thread closes
     apr_thread_join(&dummy, nm->thread);
 
     log_printf(15, "close_server_port: port=%d After join\n", nm->port);
-    tbx_flush_log();
+    tbx_log_flush();
 
     //** Free the actual struct
     free(nm->address);
@@ -652,7 +652,7 @@ void _close_ns(tbx_ns_t *ns)
 {
 
     log_printf(10, "tbx_ns_close:  Closing stream ns=%d type=%d\n", ns->id, ns->sock_type);
-    tbx_flush_log();
+    tbx_log_flush();
 
     ns->cuid = -1;
     if (ns->sock == NULL) return;

--- a/src/toolbox/pigeon_coop.c
+++ b/src/toolbox/pigeon_coop.c
@@ -76,14 +76,14 @@ tbx_pch_t pigeon_coop_iterator_next(tbx_pc_iter_t *pci)
         pch.hole = -1;
         pch.data = NULL;
 
-//log_printf(10, "pigeon_coop_iterator_next: pc=%s nothing left 1\n", pc->name); tbx_flush_log();
+//log_printf(10, "pigeon_coop_iterator_next: pc=%s nothing left 1\n", pc->name); tbx_log_flush();
 
         return(pch);
     }
 
     apr_thread_mutex_lock(pc->lock);
 
-//log_printf(10, "pigeon_coop_iterator_next: pc=%s nshelves=%d nused=%d\n", pc->name, pc->nshelves, pc->nused); tbx_flush_log();
+//log_printf(10, "pigeon_coop_iterator_next: pc=%s nshelves=%d nused=%d\n", pc->name, pc->nshelves, pc->nused); tbx_log_flush();
 
     //** Check if coop contracted since last call
     if (pci->shelf >= pc->nshelves) {
@@ -92,7 +92,7 @@ tbx_pch_t pigeon_coop_iterator_next(tbx_pc_iter_t *pci)
         pch.hole = -1;
         pch.data = NULL;
 
-//log_printf(10, "pigeon_coop_iterator_next: pc=%s nothing left 2\n", pc->name); tbx_flush_log();
+//log_printf(10, "pigeon_coop_iterator_next: pc=%s nothing left 2\n", pc->name); tbx_log_flush();
         return(pch);
     }
 
@@ -103,7 +103,7 @@ tbx_pch_t pigeon_coop_iterator_next(tbx_pc_iter_t *pci)
         pch.hole = slot;
         pch.data = &(pc->data_shelf[pch.shelf][pch.hole*pc->item_size]);
 
-//log_printf(10, "pigeon_coop_iterator_next: pc=%s FOUND-1 shelf=%d slot=%d\n", pc->name, pch.shelf, pch.hole); tbx_flush_log();
+//log_printf(10, "pigeon_coop_iterator_next: pc=%s FOUND-1 shelf=%d slot=%d\n", pc->name, pch.shelf, pch.hole); tbx_log_flush();
 
         apr_thread_mutex_unlock(pc->lock);
 
@@ -119,7 +119,7 @@ tbx_pch_t pigeon_coop_iterator_next(tbx_pc_iter_t *pci)
                     pch.shelf = pci->shelf;
                     pch.hole = slot;
                     pch.data = (void *)&(pc->data_shelf[pch.shelf][pch.hole*pc->item_size]);
-//log_printf(10, "pigeon_coop_iterator_next: pc=%s FOUND-2 shelf=%d slot=%d\n", pc->name, pch.shelf, pch.hole); tbx_flush_log();
+//log_printf(10, "pigeon_coop_iterator_next: pc=%s FOUND-2 shelf=%d slot=%d\n", pc->name, pch.shelf, pch.hole); tbx_log_flush();
                     apr_thread_mutex_unlock(pc->lock);
                     return(pch);
                 }
@@ -185,7 +185,7 @@ int tbx_pch_release(tbx_pc_t *pc, tbx_pch_t *pch)
         }
 
         log_printf(10, "release_pigeon_coop_hole: pc=%s Attempting to free shelves.  nshelves=%d last_used=%d nused=%d\n", pc->name, pc->nshelves, n, pc->nused);
-        tbx_flush_log();
+        tbx_log_flush();
         n = i+1;
 
         if (n < pc->nshelves) {
@@ -204,7 +204,7 @@ int tbx_pch_release(tbx_pc_t *pc, tbx_pch_t *pch)
             assert(pc->data_shelf != NULL);
 
             log_printf(10, "release_pigeon_coop_hole: pc=%s after free shelves.  nshelves=%d nused=%d\n", pc->name, pc->nshelves, pc->nused);
-            tbx_flush_log();
+            tbx_log_flush();
 
         }
     }
@@ -282,7 +282,7 @@ void tbx_pc_destroy(tbx_pc_t *pc)
     apr_pool_destroy(pc->pool);
 
     for (i=0; i<pc->nshelves; i++) {
-//log_printf(10, "destroy_pigeon_coop: pc=%s nshelves=%d i=%d\n", pc->name, pc->nshelves, i); tbx_flush_log();
+//log_printf(10, "destroy_pigeon_coop: pc=%s nshelves=%d i=%d\n", pc->name, pc->nshelves, i); tbx_log_flush();
         destroy_pigeon_hole(pc->ph_shelf[i]);
         pc->free(pc->new_arg, pc->shelf_size, pc->data_shelf[i]);
     }

--- a/src/toolbox/random.c
+++ b/src/toolbox/random.c
@@ -84,7 +84,7 @@ void random_seed(const void *buf, int nbytes)
 // get_random - Gets nbytes  of random data and placed it in buf.
 //*******************************************************************
 
-int tbx_random_bytes_get(void *buf, int nbytes)
+int tbx_random_get_bytes(void *buf, int nbytes)
 {
     int err;
 
@@ -108,7 +108,7 @@ double random_double(double lo, double hi)
     uint64_t rn;
 
     rn = 0;
-    tbx_random_bytes_get(&rn, sizeof(rn));
+    tbx_random_get_bytes(&rn, sizeof(rn));
     dn = (1.0 * rn) / (UINT64_MAX + 1.0);
 
     n = lo + (hi - lo) * dn;
@@ -120,7 +120,7 @@ double random_double(double lo, double hi)
 // Returns a random integer within the given range
 //*******************************************************************
 
-int64_t tbx_random_int64(int64_t lo, int64_t hi)
+int64_t tbx_random_get_int64(int64_t lo, int64_t hi)
 {
     int64_t n, dn;
 

--- a/src/toolbox/skiplist.c
+++ b/src/toolbox/skiplist.c
@@ -140,8 +140,8 @@ int tbx_sl_init_full(tbx_sl_t * self,
     self->allow_dups = allow_dups;
     self->compare = compare;
     self->dup = (dup == NULL) ? sl_passthru_dup : dup;
-    self->key_free = (key_free == NULL) ? tbx_sl_no_key_free : key_free;
-    self->data_free = (data_free == NULL) ? tbx_sl_no_data_free : data_free;
+    self->key_free = (key_free == NULL) ? tbx_sl_free_no_key : key_free;
+    self->data_free = (data_free == NULL) ? tbx_sl_free_no_data : data_free;
     self->head = create_skiplist_node(maxlevels-1);
     if (!self->head)
         goto error_1;
@@ -231,23 +231,23 @@ tbx_sl_key_t *sl_passthru_dup(tbx_sl_key_t *key)
 {
     return(key);
 }
-void tbx_sl_no_key_free(tbx_sl_key_t *key)
+void tbx_sl_free_no_key(tbx_sl_key_t *key)
 {
     log_printf(15, "key p=%p\n", key);
     return;
 }
-void tbx_sl_no_data_free(tbx_sl_data_t *data)
+void tbx_sl_free_no_data(tbx_sl_data_t *data)
 {
     log_printf(15, "data p=%p\n", data);
     return;
 }
-void tbx_sl_simple_free(tbx_sl_data_t *data)
+void tbx_sl_free_simple(tbx_sl_data_t *data)
 {
     log_printf(15, "p=%p\n", data);
     free(data);
 }
 
-tbx_sl_key_t *tbx_sl_string_dup(tbx_sl_key_t *key)
+tbx_sl_key_t *tbx_sl_dup_string(tbx_sl_key_t *key)
 {
     char *dup = strdup((char *)key);
     return((tbx_sl_key_t *)dup);
@@ -317,7 +317,7 @@ int skiplist_compare_fn_strncmp(void *arg, tbx_sl_key_t *k1, tbx_sl_key_t *k2)
     return(strncmp(a,b, n));
 }
 
-void tbx_sl_strncmp_set(tbx_sl_compare_t *compare, int n)
+void tbx_sl_set_strncmp(tbx_sl_compare_t *compare, int n)
 {
     long l = n;
     compare->fn = skiplist_compare_fn_strncmp;
@@ -442,7 +442,7 @@ tbx_sl_key_t *tbx_sl_first_key(tbx_sl_t *sl)
 // skiplist_last_key - Returns the last key in the list
 //*********************************************************************************
 
-tbx_sl_key_t *tbx_sl_last_key(tbx_sl_t *sl)
+tbx_sl_key_t *tbx_sl_key_last(tbx_sl_t *sl)
 {
     tbx_sl_node_t *ptr[SKIPLIST_MAX_LEVEL];
     if (sl->n_keys <= 0) return(NULL);

--- a/src/toolbox/sl_test.c
+++ b/src/toolbox/sl_test.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 
 
     printf("Checking access to the last key\n");
-    key = tbx_sl_last_key(sl);
+    key = tbx_sl_key_last(sl);
     if (*key != max_key) {
         printf("ERROR getting last key! max_key=%d got=%d\n", max_key, *key);
     }
@@ -342,7 +342,7 @@ int main(int argc, char **argv)
 
     tbx_sl_del(sl);
     fflush(stdout);
-    tbx_flush_log();
+    tbx_log_flush();
 
     free(key_list);
     free(data_list);

--- a/src/toolbox/stack.c
+++ b/src/toolbox/stack.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "tbx/stack.h"
 #include "stack.h"
 
@@ -27,13 +28,23 @@
 #define MOVE_BOTH    3
 
 // Accessors
-tbx_stack_ele_t * tbx_stack_top_get(tbx_stack_t * stack) {
+tbx_stack_ele_t * tbx_stack_get_top(tbx_stack_t * stack) {
     return stack->top;
 }
 
 tbx_stack_ele_t * tbx_stack_ele_get_down(tbx_stack_ele_t * stack) {
     return stack->down;
 }
+
+// Boilerplate for tbs_stack_t
+TBX_TYPE_SIZEOF_DEFAULT(tbx_stack_t, tbx_stack);
+TBX_TYPE_INIT_DEFAULT(tbx_stack_t, tbx_stack);
+TBX_TYPE_FINI_DEFAULT(tbx_stack_t, tbx_stack);
+TBX_TYPE_NEW_DEFAULT(tbx_stack_t, tbx_stack);
+TBX_TYPE_DEL_DEFAULT(tbx_stack_t, tbx_stack);
+
+
+
 //void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele) {
 //    return ele->data;
 //}
@@ -58,7 +69,7 @@ int check_ends(tbx_stack_t *stack)
 // stack_size - Returns the number of elements in the stack
 //**************************************
 
-int tbx_stack_size(tbx_stack_t *stack)
+int tbx_stack_count(tbx_stack_t *stack)
 {
     return(stack->n);
 }
@@ -80,33 +91,6 @@ void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele)
 void set_stack_ele_data(tbx_stack_ele_t *ele, void *data)
 {
     if (ele != NULL) ele->data = data;
-}
-
-//**************************************
-//tbx_stack_new - Creates a new stack
-//**************************************
-
-void tbx_stack_init(tbx_stack_t *stack)
-{
-    stack->top = NULL;
-    stack->bottom = NULL;
-    stack->curr = NULL;
-    stack->n = 0;
-}
-
-//**************************************
-//tbx_stack_new - Creates a new stack
-//**************************************
-
-tbx_stack_t *tbx_stack_new()
-{
-    tbx_stack_t *stack;
-
-    stack = (tbx_stack_t *)malloc(sizeof(tbx_stack_t));
-
-    tbx_stack_init(stack);
-
-    return(stack);
 }
 
 //***************************************************

--- a/src/toolbox/stack.c
+++ b/src/toolbox/stack.c
@@ -31,12 +31,12 @@ tbx_stack_ele_t * tbx_stack_top_get(tbx_stack_t * stack) {
     return stack->top;
 }
 
-tbx_stack_ele_t * tbx_stack_ele_down_get(tbx_stack_ele_t * stack) {
+tbx_stack_ele_t * tbx_stack_ele_get_down(tbx_stack_ele_t * stack) {
     return stack->down;
 }
-void *tbx_stack_ele_data_get(tbx_stack_ele_t *ele) {
-    return ele->data;
-}
+//void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele) {
+//    return ele->data;
+//}
 
 //**************************************
 // check_ends - Checks to see if an
@@ -67,7 +67,7 @@ int tbx_stack_size(tbx_stack_t *stack)
 // get_stack_ele_data - Returns the data associated with a tbx_stack_ele_t structure
 //**************************************
 
-void *tbx_get_stack_ele_data(tbx_stack_ele_t *ele)
+void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele)
 {
     if (ele == NULL) return(NULL);
     return(ele->data);
@@ -128,11 +128,11 @@ void tbx_stack_empty(tbx_stack_t *stack, int data_also)
 }
 
 //***************************************************
-//tbx_free_stack - frees a stack.  If data_also == 1 then
+//tbx_stack_free - frees a stack.  If data_also == 1 then
 //     the data is also freed.
 //***************************************************
 
-void tbx_free_stack(tbx_stack_t *stack, int data_also)
+void tbx_stack_free(tbx_stack_t *stack, int data_also)
 {
     tbx_stack_empty(stack, data_also);
     free(stack);
@@ -142,12 +142,12 @@ void tbx_free_stack(tbx_stack_t *stack, int data_also)
 //  dup_stack - Duplicates a stack
 //***************************************************
 
-void tbx_dup_stack(tbx_stack_t *new, tbx_stack_t *old)
+void tbx_stack_dup(tbx_stack_t *new, tbx_stack_t *old)
 {
     void *ptr;
 
     tbx_stack_move_to_bottom(old);
-    while ((ptr = tbx_get_ele_data(old)) != NULL) {
+    while ((ptr = tbx_stack_get_current_data(old)) != NULL) {
         tbx_stack_push(new, ptr);
         tbx_stack_move_up(old);
     }
@@ -157,7 +157,7 @@ void tbx_dup_stack(tbx_stack_t *new, tbx_stack_t *old)
 // push_link - push an unlinked element on top of the stack
 //***************************************************
 
-void tbx_push_link(tbx_stack_t *stack, tbx_stack_ele_t *ele)
+void tbx_stack_link_push(tbx_stack_t *stack, tbx_stack_ele_t *ele)
 {
     ele->down = stack->top;
     ele->up = NULL;
@@ -185,7 +185,7 @@ void tbx_stack_push(tbx_stack_t *stack, void *data)
     ele = (tbx_stack_ele_t *)malloc(sizeof(tbx_stack_ele_t));
     ele->data = data;
 
-    tbx_push_link(stack, ele);
+    tbx_stack_link_push(stack, ele);
 }
 
 //***************************************************
@@ -236,10 +236,10 @@ void *tbx_stack_pop(tbx_stack_t *stack)
 }
 
 //***************************************************
-//  tbx_get_ptr - Returns a ptr to the current stack element
+//  tbx_stack_get_current_ptr - Returns a ptr to the current stack element
 //***************************************************
 
-tbx_stack_ele_t *tbx_get_ptr(tbx_stack_t *stack)
+tbx_stack_ele_t *tbx_stack_get_current_ptr(tbx_stack_t *stack)
 {
 
     if (stack->curr) {
@@ -250,10 +250,10 @@ tbx_stack_ele_t *tbx_get_ptr(tbx_stack_t *stack)
 }
 
 //***************************************************
-//  tbx_get_ele_data - Returns the current elements data
+//  tbx_stack_get_current_data - Returns the current elements data
 //***************************************************
 
-void *tbx_get_ele_data(tbx_stack_t *stack)
+void *tbx_stack_get_current_data(tbx_stack_t *stack)
 {
 
     if (stack->curr) {
@@ -358,7 +358,7 @@ int insert_link_below(tbx_stack_t *stack, tbx_stack_ele_t *ele)
         printf("insert_link_below: Can't determine position!!!!!!!! move_ends = %d\n",move_ends);
         return(0);         // Can't determine position since curr=NULL
     } else {
-        tbx_push_link(stack, ele);
+        tbx_stack_link_push(stack, ele);
         return(1);
     }
 }
@@ -388,7 +388,7 @@ int tbx_stack_insert_below(tbx_stack_t *stack, void *data)
 //    "above" the current element.
 //***************************************************
 
-int tbx_stack_insert_link_above(tbx_stack_t *stack, tbx_stack_ele_t *ele)
+int tbx_stack_link_insert_above(tbx_stack_t *stack, tbx_stack_ele_t *ele)
 {
     int move_ends;
 
@@ -410,7 +410,7 @@ int tbx_stack_insert_link_above(tbx_stack_t *stack, tbx_stack_ele_t *ele)
     } else if (stack->top) {
         return(0);         // Can't determine position since curr=NULL
     } else {
-        tbx_push_link(stack, ele);
+        tbx_stack_link_push(stack, ele);
         return(1);
     }
 }
@@ -426,7 +426,7 @@ int tbx_stack_insert_above(tbx_stack_t *stack, void *data)
 
     ele =(tbx_stack_ele_t *) malloc(sizeof(tbx_stack_ele_t));
     ele->data = data;
-    int ret = tbx_stack_insert_link_above(stack, ele);
+    int ret = tbx_stack_link_insert_above(stack, ele);
     if (!ret)
         free(ele);
     return ret;
@@ -476,7 +476,7 @@ tbx_stack_ele_t *tbx_stack_unlink_current(tbx_stack_t *stack, int mv_up)
 //     below (mv_up=0) the deleted element.
 //***************************************************
 
-int tbx_delete_current(tbx_stack_t *stack, int mv_up, int data_also)
+int tbx_stack_delete_current(tbx_stack_t *stack, int mv_up, int data_also)
 {
     tbx_stack_ele_t *ele = tbx_stack_unlink_current(stack, mv_up);
 

--- a/src/toolbox/tbx/dns_cache.h
+++ b/src/toolbox/tbx/dns_cache.h
@@ -25,13 +25,10 @@ extern "C" {
 #endif
 
 // Functions
-TBX_API int tbx_dnsc_startup();
-
-TBX_API int tbx_dnsc_shutdown();
-
-TBX_API int tbx_dnsc_startup_sized(int size);
-
 TBX_API int tbx_dnsc_lookup(const char * name, char * byte_addr, char * ip_addr);
+TBX_API int tbx_dnsc_shutdown();
+TBX_API int tbx_dnsc_startup();
+TBX_API int tbx_dnsc_startup_sized(int size);
 
 // Preprocessor macros
 #define DNS_ADDR_MAX 4

--- a/src/toolbox/tbx/iniparse.h
+++ b/src/toolbox/tbx/iniparse.h
@@ -34,40 +34,23 @@ typedef struct tbx_inip_group_t tbx_inip_group_t;
 
 // Functions
 TBX_API void tbx_inip_destroy(tbx_inip_file_t *inip);
-
-TBX_API tbx_inip_group_t *tbx_inip_group_find(tbx_inip_file_t *inip, const char *name);
-
-TBX_API char *tbx_inip_find_key(tbx_inip_group_t *group, const char *name);
-
 TBX_API tbx_inip_element_t *tbx_inip_ele_first(tbx_inip_group_t *group);
-
-TBX_API tbx_inip_group_t *tbx_inip_group_first(tbx_inip_file_t *inip);
-
-TBX_API char *tbx_inip_group_get(tbx_inip_group_t *g);
-
-TBX_API double tbx_inip_get_double(tbx_inip_file_t *inip, const char *group, const char *key, double def);
-
 TBX_API char *tbx_inip_ele_get_key(tbx_inip_element_t *ele);
-
 TBX_API char *tbx_inip_ele_get_value(tbx_inip_element_t *ele);
-
-TBX_API int64_t tbx_inip_get_integer(tbx_inip_file_t *inip, const char *group, const char *key, int64_t def);
-
-TBX_API char *tbx_inip_get_string(tbx_inip_file_t *inip, const char *group, const char *key, char *def);
-
-TBX_API void tbx_inip_group_free(tbx_inip_group_t *g);
-
-TBX_API void tbx_inip_group_set(tbx_inip_group_t *ig, char *value);
-
-TBX_API int tbx_inip_group_count(tbx_inip_file_t *inip);
-
 TBX_API tbx_inip_element_t *tbx_inip_ele_next(tbx_inip_element_t *ele);
-
+TBX_API tbx_inip_file_t *tbx_inip_file_read(const char *fname);
+TBX_API char *tbx_inip_find_key(tbx_inip_group_t *group, const char *name);
+TBX_API double tbx_inip_get_double(tbx_inip_file_t *inip, const char *group, const char *key, double def);
+TBX_API int64_t tbx_inip_get_integer(tbx_inip_file_t *inip, const char *group, const char *key, int64_t def);
+TBX_API char *tbx_inip_get_string(tbx_inip_file_t *inip, const char *group, const char *key, char *def);
+TBX_API int tbx_inip_group_count(tbx_inip_file_t *inip);
+TBX_API tbx_inip_group_t *tbx_inip_group_find(tbx_inip_file_t *inip, const char *name);
+TBX_API tbx_inip_group_t *tbx_inip_group_first(tbx_inip_file_t *inip);
+TBX_API void tbx_inip_group_free(tbx_inip_group_t *g);
+TBX_API char *tbx_inip_group_get(tbx_inip_group_t *g);
 TBX_API tbx_inip_group_t *tbx_inip_group_next(tbx_inip_group_t *g);
-
-TBX_API tbx_inip_file_t *tbx_inip_read_file(const char *fname);
-
-TBX_API tbx_inip_file_t *tbx_inip_read_string(const char *text);
+TBX_API void tbx_inip_group_set(tbx_inip_group_t *ig, char *value);
+TBX_API tbx_inip_file_t *tbx_inip_string_read(const char *text);
 
 #ifdef __cplusplus
 }

--- a/src/toolbox/tbx/iniparse.h
+++ b/src/toolbox/tbx/iniparse.h
@@ -37,7 +37,7 @@ TBX_API void tbx_inip_destroy(tbx_inip_file_t *inip);
 
 TBX_API tbx_inip_group_t *tbx_inip_group_find(tbx_inip_file_t *inip, const char *name);
 
-TBX_API char *tbx_inip_key_find(tbx_inip_group_t *group, const char *name);
+TBX_API char *tbx_inip_find_key(tbx_inip_group_t *group, const char *name);
 
 TBX_API tbx_inip_element_t *tbx_inip_ele_first(tbx_inip_group_t *group);
 
@@ -45,29 +45,29 @@ TBX_API tbx_inip_group_t *tbx_inip_group_first(tbx_inip_file_t *inip);
 
 TBX_API char *tbx_inip_group_get(tbx_inip_group_t *g);
 
-TBX_API double tbx_inip_double_get(tbx_inip_file_t *inip, const char *group, const char *key, double def);
+TBX_API double tbx_inip_get_double(tbx_inip_file_t *inip, const char *group, const char *key, double def);
 
-TBX_API char *tbx_inip_ele_key_get(tbx_inip_element_t *ele);
+TBX_API char *tbx_inip_ele_get_key(tbx_inip_element_t *ele);
 
-TBX_API char *tbx_inip_ele_value_get(tbx_inip_element_t *ele);
+TBX_API char *tbx_inip_ele_get_value(tbx_inip_element_t *ele);
 
-TBX_API int64_t tbx_inip_integer_get(tbx_inip_file_t *inip, const char *group, const char *key, int64_t def);
+TBX_API int64_t tbx_inip_get_integer(tbx_inip_file_t *inip, const char *group, const char *key, int64_t def);
 
-TBX_API char *tbx_inip_string_get(tbx_inip_file_t *inip, const char *group, const char *key, char *def);
+TBX_API char *tbx_inip_get_string(tbx_inip_file_t *inip, const char *group, const char *key, char *def);
 
 TBX_API void tbx_inip_group_free(tbx_inip_group_t *g);
 
 TBX_API void tbx_inip_group_set(tbx_inip_group_t *ig, char *value);
 
-TBX_API int tbx_inip_n_groups(tbx_inip_file_t *inip);
+TBX_API int tbx_inip_group_count(tbx_inip_file_t *inip);
 
 TBX_API tbx_inip_element_t *tbx_inip_ele_next(tbx_inip_element_t *ele);
 
 TBX_API tbx_inip_group_t *tbx_inip_group_next(tbx_inip_group_t *g);
 
-TBX_API tbx_inip_file_t *tbx_inip_file_read(const char *fname);
+TBX_API tbx_inip_file_t *tbx_inip_read_file(const char *fname);
 
-TBX_API tbx_inip_file_t *tbx_inip_string_read(const char *text);
+TBX_API tbx_inip_file_t *tbx_inip_read_string(const char *text);
 
 #ifdef __cplusplus
 }

--- a/src/toolbox/tbx/interval_skiplist.h
+++ b/src/toolbox/tbx/interval_skiplist.h
@@ -33,6 +33,12 @@ typedef struct tbx_isl_node_t tbx_isl_node_t;
 
 typedef struct tbx_isl_t tbx_isl_t;
 
+typedef tbx_sl_key_t *(*tbx_isl_dup_fn_t)(tbx_sl_key_t *a);
+
+typedef void (*tbx_isl_key_free_fn_t)(tbx_sl_key_t *a);
+
+typedef void (*tbx_isl_data_free_fn_t)(tbx_sl_data_t *a);
+
 // Functions
 TBX_API int tbx_isl_count2(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi);
 TBX_API void tbx_isl_del(tbx_isl_t *isl);
@@ -41,14 +47,14 @@ TBX_API tbx_isl_iter_t tbx_isl_iter_search(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx
 TBX_API tbx_sl_key_t *tbx_isl_key_first(tbx_isl_t *isl);
 TBX_API tbx_sl_key_t *tbx_isl_key_last(tbx_isl_t *isl);
 TBX_API tbx_isl_t *tbx_isl_new(tbx_sl_compare_t *compare,
-        tbx_sl_key_t *(*dup)(tbx_sl_key_t *a),
-        void (*key_free)(tbx_sl_key_t *a),
-        void (*data_free)(tbx_sl_data_t *a));
+        tbx_isl_dup_fn_t dup,
+        tbx_isl_key_free_fn_t key_free,
+        tbx_isl_data_free_fn_t data_free);
 TBX_API tbx_isl_t *tbx_isl_new_full(int maxlevels, double p,
         tbx_sl_compare_t *compare,
-        tbx_sl_key_t *(*dup)(tbx_sl_key_t *a),
-        void (*key_free)(tbx_sl_key_t *a),
-        void (*data_free)(tbx_sl_data_t *a));
+        tbx_isl_dup_fn_t dup,
+        tbx_isl_key_free_fn_t key_free,
+        tbx_isl_data_free_fn_t data_free);
 TBX_API tbx_sl_data_t *tbx_isl_next(tbx_isl_iter_t *it);
 TBX_API int tbx_isl_remove(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_data_t *data);
 

--- a/src/toolbox/tbx/interval_skiplist.h
+++ b/src/toolbox/tbx/interval_skiplist.h
@@ -35,30 +35,21 @@ typedef struct tbx_isl_t tbx_isl_t;
 
 // Functions
 TBX_API int tbx_isl_count2(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi);
-
+TBX_API void tbx_isl_del(tbx_isl_t *isl);
+TBX_API int tbx_isl_insert(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_data_t *data);
+TBX_API tbx_isl_iter_t tbx_isl_iter_search(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi);
+TBX_API tbx_sl_key_t *tbx_isl_key_first(tbx_isl_t *isl);
+TBX_API tbx_sl_key_t *tbx_isl_key_last(tbx_isl_t *isl);
 TBX_API tbx_isl_t *tbx_isl_new(tbx_sl_compare_t *compare,
         tbx_sl_key_t *(*dup)(tbx_sl_key_t *a),
         void (*key_free)(tbx_sl_key_t *a),
         void (*data_free)(tbx_sl_data_t *a));
-
 TBX_API tbx_isl_t *tbx_isl_new_full(int maxlevels, double p,
         tbx_sl_compare_t *compare,
         tbx_sl_key_t *(*dup)(tbx_sl_key_t *a),
         void (*key_free)(tbx_sl_key_t *a),
         void (*data_free)(tbx_sl_data_t *a));
-
-TBX_API void tbx_isl_del(tbx_isl_t *isl);
-
-TBX_API int tbx_isl_insert(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_data_t *data);
-
-TBX_API tbx_sl_key_t *tbx_isl_key_first(tbx_isl_t *isl);
-
-TBX_API tbx_sl_key_t *tbx_isl_key_last(tbx_isl_t *isl);
-
-TBX_API tbx_isl_iter_t tbx_isl_iter_search(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi);
-
 TBX_API tbx_sl_data_t *tbx_isl_next(tbx_isl_iter_t *it);
-
 TBX_API int tbx_isl_remove(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_data_t *data);
 
 // Preprocessor macros

--- a/src/toolbox/tbx/list.h
+++ b/src/toolbox/tbx/list.h
@@ -40,21 +40,21 @@ extern "C" {
 
 #define tbx_list_next(it, nkey, ndata) tbx_sl_next(it, nkey, ndata)
 
-#define tbx_list_no_data_free tbx_sl_no_data_free
+#define tbx_list_no_data_free tbx_sl_free_no_data
 
-#define tbx_list_no_key_free tbx_sl_no_key_free
+#define tbx_list_no_key_free tbx_sl_free_no_key
 
 #define tbx_list_remove(sl, key, data) tbx_sl_remove(sl, key, data)
 
 #define tbx_list_search(sl, key) tbx_sl_search_compare(sl, key, (sl)->compare)
 
-#define tbx_list_simple_free tbx_sl_simple_free
+#define tbx_list_simple_free tbx_sl_free_simple
 
 #define tbx_list_string_compare tbx_sl_compare_strcmp
 
-#define tbx_list_string_dup tbx_sl_string_dup
+#define tbx_list_string_dup tbx_sl_dup_string
 
-#define tbx_list_strncmp_set(cmp, n) tbx_sl_strncmp_set(cmp, n)
+#define tbx_list_strncmp_set(cmp, n) tbx_sl_set_strncmp(cmp, n)
 // TEMPORARY
 #if !defined toolbox_EXPORTS && defined LSTORE_HACK_EXPORT
 #   include <tbx/skiplist.h>

--- a/src/toolbox/tbx/log.h
+++ b/src/toolbox/tbx/log.h
@@ -29,7 +29,7 @@ extern "C" {
 typedef struct tbx_log_fd_t tbx_log_fd_t;
 
 // Functions
-TBX_API void tbx_open_log(char *fname, int dolock);
+TBX_API void tbx_log_open(char *fname, int dolock);
 
 TBX_API tbx_log_fd_t *tbx_info_create(FILE *fd, int header_type, int level);
 
@@ -41,9 +41,9 @@ TBX_API void tbx_mlog_load(char *fname, char *output_override, int log_level_ove
 
 TBX_API int tbx_mlog_printf(int suppress_header, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
 
-TBX_API void tbx_flush_log();
+TBX_API void tbx_log_flush();
 
-TBX_API int tbx_get_info_level(tbx_log_fd_t *fd);
+TBX_API int tbx_stack_get_info_level(tbx_log_fd_t *fd);
 
 // Preprocessor macros
 #define _mlog_size 1024

--- a/src/toolbox/tbx/log.h
+++ b/src/toolbox/tbx/log.h
@@ -29,20 +29,13 @@ extern "C" {
 typedef struct tbx_log_fd_t tbx_log_fd_t;
 
 // Functions
-TBX_API void tbx_log_open(char *fname, int dolock);
-
 TBX_API tbx_log_fd_t *tbx_info_create(FILE *fd, int header_type, int level);
-
 TBX_API void tbx_info_flush(tbx_log_fd_t *ifd);
-
-TBX_API int tbx_minfo_printf(tbx_log_fd_t *ifd, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
-
-TBX_API void tbx_mlog_load(char *fname, char *output_override, int log_level_override);
-
-TBX_API int tbx_mlog_printf(int suppress_header, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
-
 TBX_API void tbx_log_flush();
-
+TBX_API void tbx_log_open(char *fname, int dolock);
+TBX_API int tbx_minfo_printf(tbx_log_fd_t *ifd, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
+TBX_API void tbx_mlog_load(char *fname, char *output_override, int log_level_override);
+TBX_API int tbx_mlog_printf(int suppress_header, int module_index, int level, const char *fn, const char *fname, int line, const char *fmt, ...) __attribute__((format (printf, 7, 8)));
 TBX_API int tbx_stack_get_info_level(tbx_log_fd_t *fd);
 
 // Preprocessor macros

--- a/src/toolbox/tbx/network.h
+++ b/src/toolbox/tbx/network.h
@@ -40,62 +40,36 @@ typedef struct tbx_ns_t tbx_ns_t;
 typedef apr_time_t tbx_ns_timeout_t;
 
 // Functions
-TBX_API void tbx_ns_close(tbx_ns_t *ns);
-
-TBX_API void tbx_ns_destroy(tbx_ns_t *ns);
-
-TBX_API int tbx_ns_connect(tbx_ns_t *ns, const char *hostname, int port, tbx_ns_timeout_t timeout);
-
-TBX_API int tbx_network_counter(tbx_network_t *net);
-
-TBX_API tbx_ns_t *tbx_ns_new();
-
-TBX_API int tbx_ns_chksum_is_valid(tbx_ns_chksum_t *ncs);
-
-TBX_API int tbx_ns_chksum_reset(tbx_ns_chksum_t *ncs);
-
-TBX_API int tbx_ns_chksum_set(tbx_ns_chksum_t *ncs, tbx_chksum_t *cks, size_t blocksize);
-
-TBX_API int tbx_ns_generate_id();
-
-TBX_API int tbx_ns_getid(tbx_ns_t *ns);
-
-TBX_API int tbx_ns_chksum_read_flush(tbx_ns_t *ns);
-
 TBX_API void  tbx_ns_setid(tbx_ns_t *ns, int id);
-
+TBX_API int tbx_network_counter(tbx_network_t *net);
+TBX_API int tbx_ns_chksum_is_valid(tbx_ns_chksum_t *ncs);
 TBX_API void tbx_ns_chksum_read_clear(tbx_ns_t *ns);
-
 TBX_API void tbx_ns_chksum_read_disable(tbx_ns_t *ns);
-
 TBX_API void tbx_ns_chksum_read_enable(tbx_ns_t *ns);
-
+TBX_API int tbx_ns_chksum_read_flush(tbx_ns_t *ns);
 TBX_API void tbx_ns_chksum_read_set(tbx_ns_t *ns, tbx_ns_chksum_t ncs);
-
-TBX_API int tbx_ns_chksum_write_flush(tbx_ns_t *ns);
-
+TBX_API int tbx_ns_chksum_reset(tbx_ns_chksum_t *ncs);
+TBX_API int tbx_ns_chksum_set(tbx_ns_chksum_t *ncs, tbx_chksum_t *cks, size_t blocksize);
 TBX_API void tbx_ns_chksum_write_clear(tbx_ns_t *ns);
-
 TBX_API void tbx_ns_chksum_write_disable(tbx_ns_t *ns);
-
 TBX_API void tbx_ns_chksum_write_enable(tbx_ns_t *ns);
-
+TBX_API int tbx_ns_chksum_write_flush(tbx_ns_t *ns);
 TBX_API void tbx_ns_chksum_write_set(tbx_ns_t *ns, tbx_ns_chksum_t ncs);
-
+TBX_API void tbx_ns_close(tbx_ns_t *ns);
+TBX_API int tbx_ns_connect(tbx_ns_t *ns, const char *hostname, int port, tbx_ns_timeout_t timeout);
+TBX_API void tbx_ns_destroy(tbx_ns_t *ns);
+TBX_API int tbx_ns_generate_id();
+TBX_API int tbx_ns_getid(tbx_ns_t *ns);
+TBX_API tbx_ns_t *tbx_ns_new();
 TBX_API int tbx_ns_read(tbx_ns_t *ns, tbx_tbuf_t *buffer, int boff, int size, tbx_ns_timeout_t timeout);
-
 TBX_API int tbx_ns_readline_raw(tbx_ns_t *ns, tbx_tbuf_t *buffer, int boff, int size, tbx_ns_timeout_t timeout, int *status);
-
 TBX_API tbx_ns_timeout_t *tbx_ns_timeout_set(tbx_ns_timeout_t *tm, int sec, int us);
-
 TBX_API int tbx_ns_write(tbx_ns_t *ns, tbx_tbuf_t *buffer, int boff, int bsize, tbx_ns_timeout_t timeout);
 
 // Stubs for unused code
 // FIXME: Delete these
 TBX_API void tbx_ns_config_1_ssl(tbx_ns_t *ns, int fd, int tcpsize);
 TBX_API void tbx_ns_config_2_ssl(tbx_ns_t *ns, int tcpsize);
-
-
 
 // Precompiler macros
 #define tbx_ns_chksum_type(ncs) (ncs)->chksum.type
@@ -111,8 +85,6 @@ TBX_API void tbx_ns_config_2_ssl(tbx_ns_t *ns, int tcpsize);
 #define NS_TYPE_2_SSL    4      //** Dual SSL connection -- Allows use of separate R/W locks over SSL much faster than prev
 #define NS_TYPE_ZSOCK	 5	//** ZMQ implementation
 #define NS_TYPE_MAX      6      //** Not an actual type just the number of different types
-
-
 
 // TEMPORARY
 #if !defined toolbox_EXPORTS && defined LSTORE_HACK_EXPORT

--- a/src/toolbox/tbx/packer.h
+++ b/src/toolbox/tbx/packer.h
@@ -33,21 +33,13 @@ typedef struct tbx_pack_zlib_t tbx_pack_zlib_t;
 
 // Functions
 TBX_API void tbx_pack_consumed(tbx_pack_t *pack);
-
 TBX_API tbx_pack_t *tbx_pack_create(int type, int mode, unsigned char *buffer, unsigned int bufsize);
-
 TBX_API void tbx_pack_destroy(tbx_pack_t *pack);
-
 TBX_API int tbx_pack_read(tbx_pack_t *pack, unsigned char *data, int nbytes);
-
 TBX_API int tbx_pack_read_new_data(tbx_pack_t *pack, unsigned char *buffer, unsigned int bufsize);
-
 TBX_API int tbx_pack_used(tbx_pack_t *pack);
-
 TBX_API int tbx_pack_write(tbx_pack_t *pack, unsigned char *data, int nbytes);
-
 TBX_API int tbx_pack_write_flush(tbx_pack_t *pack);
-
 TBX_API void tbx_pack_write_resized(tbx_pack_t *pack, unsigned char *buffer, unsigned int bufsize);
 
 // Preprocessor Macros

--- a/src/toolbox/tbx/pigeon_coop.h
+++ b/src/toolbox/tbx/pigeon_coop.h
@@ -30,15 +30,15 @@ typedef struct tbx_pc_iter_t tbx_pc_iter_t;
 typedef struct tbx_pc_t tbx_pc_t;
 
 typedef struct tbx_pch_t tbx_pch_t;
+typedef void *(*tbx_pc_new_fn_t)(void *arg, int size);
+typedef void (*tbx_pc_free_fn_t)(void *arg, int size, void *dshelf);
 
 // Functions
 TBX_API void tbx_pc_destroy(tbx_pc_t *pc);
 TBX_API tbx_pc_t *tbx_pc_new(const char *name, int size, int item_size,
                                 void *new_arg,
-                                void *(*new)(void *arg, int size),
-                                void (*free)(void *arg,
-                                                int size,
-                                                void *dshelf));
+                                tbx_pc_new_fn_t new_fn,
+                                tbx_pc_free_fn_t free);
 TBX_API void *tbx_pch_data(tbx_pch_t *pch);
 TBX_API int tbx_pch_release(tbx_pc_t *pc, tbx_pch_t *pch);
 TBX_API tbx_pch_t tbx_pch_reserve(tbx_pc_t *pc);

--- a/src/toolbox/tbx/pigeon_coop.h
+++ b/src/toolbox/tbx/pigeon_coop.h
@@ -33,13 +33,14 @@ typedef struct tbx_pch_t tbx_pch_t;
 
 // Functions
 TBX_API void tbx_pc_destroy(tbx_pc_t *pc);
-
-TBX_API tbx_pc_t *tbx_pc_new(const char *name, int size, int item_size, void *new_arg, void *(*new)(void *arg, int size),
-                               void (*free)(void *arg, int size, void *dshelf));
+TBX_API tbx_pc_t *tbx_pc_new(const char *name, int size, int item_size,
+                                void *new_arg,
+                                void *(*new)(void *arg, int size),
+                                void (*free)(void *arg,
+                                                int size,
+                                                void *dshelf));
 TBX_API void *tbx_pch_data(tbx_pch_t *pch);
-
 TBX_API int tbx_pch_release(tbx_pc_t *pc, tbx_pch_t *pch);
-
 TBX_API tbx_pch_t tbx_pch_reserve(tbx_pc_t *pc);
 
 // TEMPORARY

--- a/src/toolbox/tbx/random.h
+++ b/src/toolbox/tbx/random.h
@@ -26,13 +26,10 @@ extern "C" {
 #endif
 
 // Functions
-TBX_API int tbx_random_shutdown();
-
 TBX_API int tbx_random_get_bytes(void *buf, int nbytes);
-
-TBX_API int tbx_random_startup();
-
 TBX_API int64_t tbx_random_get_int64(int64_t lo, int64_t hi);
+TBX_API int tbx_random_shutdown();
+TBX_API int tbx_random_startup();
 
 #ifdef __cplusplus
 }

--- a/src/toolbox/tbx/random.h
+++ b/src/toolbox/tbx/random.h
@@ -28,11 +28,11 @@ extern "C" {
 // Functions
 TBX_API int tbx_random_shutdown();
 
-TBX_API int tbx_random_bytes_get(void *buf, int nbytes);
+TBX_API int tbx_random_get_bytes(void *buf, int nbytes);
 
 TBX_API int tbx_random_startup();
 
-TBX_API int64_t tbx_random_int64(int64_t lo, int64_t hi);
+TBX_API int64_t tbx_random_get_int64(int64_t lo, int64_t hi);
 
 #ifdef __cplusplus
 }

--- a/src/toolbox/tbx/skiplist.h
+++ b/src/toolbox/tbx/skiplist.h
@@ -40,6 +40,13 @@ typedef struct tbx_sl_iter_t tbx_sl_iter_t;
 
 typedef struct tbx_sl_node_t tbx_sl_node_t;
 
+typedef tbx_sl_key_t *(*tbx_sl_dup_fn_t)(tbx_sl_key_t *a);
+
+typedef void (*tbx_sl_key_free_fn_t)(tbx_sl_key_t *a);
+
+typedef void (*tbx_sl_data_free_fn_t)(tbx_sl_data_t *a);
+
+
 TBX_TYPE(tbx_sl_t, tbx_sl);
 TBX_API tbx_sl_t *tbx_sl_create_full(int maxlevels, double p, int allow_dups,
                                         tbx_sl_compare_t *compare,
@@ -48,15 +55,16 @@ TBX_API tbx_sl_t *tbx_sl_create_full(int maxlevels, double p, int allow_dups,
                                         void (*data_free)(tbx_sl_data_t *a));
 TBX_TYPE_NEW(tbx_sl_t, tbx_sl_new_full, int maxlevels, double p, int allow_dups,
                         tbx_sl_compare_t *compare,
-                        tbx_sl_key_t *(*dup)(tbx_sl_key_t *a),
-                        void (*key_free)(tbx_sl_key_t *a),
-                        void (*data_free)(tbx_sl_data_t *a));
+                        tbx_sl_dup_fn_t dup,
+                        tbx_sl_key_free_fn_t key_free,
+                        tbx_sl_data_free_fn_t data_free);
+                        
 TBX_TYPE_INIT(tbx_sl_t, tbx_sl_init_full, tbx_sl_t * self,
                         int maxlevels, double p, int allow_dups,
                         tbx_sl_compare_t *compare,
-                        tbx_sl_key_t *(*dup)(tbx_sl_key_t *a),
-                        void (*key_free)(tbx_sl_key_t *a),
-                        void (*data_free)(tbx_sl_data_t *a));
+                        tbx_sl_dup_fn_t dup,
+                        tbx_sl_key_free_fn_t key_free,
+                        tbx_sl_data_free_fn_t data_free);
 
 // Functions
 TBX_API tbx_sl_key_t *tbx_sl_dup_string(tbx_sl_key_t *key);

--- a/src/toolbox/tbx/skiplist.h
+++ b/src/toolbox/tbx/skiplist.h
@@ -75,17 +75,17 @@ TBX_API tbx_sl_key_t *tbx_sl_first_key(tbx_sl_t *sl);
 
 TBX_API int tbx_sl_key_count(tbx_sl_t *sl);
 
-TBX_API tbx_sl_key_t *tbx_sl_last_key(tbx_sl_t *sl);
+TBX_API tbx_sl_key_t *tbx_sl_key_last(tbx_sl_t *sl);
 
-TBX_API void tbx_sl_strncmp_set(tbx_sl_compare_t *compare, int n);
+TBX_API void tbx_sl_set_strncmp(tbx_sl_compare_t *compare, int n);
 
-TBX_API void tbx_sl_no_data_free(tbx_sl_data_t *data);
+TBX_API void tbx_sl_free_no_data(tbx_sl_data_t *data);
 
-TBX_API void tbx_sl_no_key_free(tbx_sl_key_t *key);
+TBX_API void tbx_sl_free_no_key(tbx_sl_key_t *key);
 
-TBX_API void tbx_sl_simple_free(tbx_sl_data_t *data);
+TBX_API void tbx_sl_free_simple(tbx_sl_data_t *data);
 
-TBX_API tbx_sl_key_t *tbx_sl_string_dup(tbx_sl_key_t *key);
+TBX_API tbx_sl_key_t *tbx_sl_dup_string(tbx_sl_key_t *key);
 
 TBX_API extern tbx_sl_compare_t tbx_sl_compare_int;
 

--- a/src/toolbox/tbx/skiplist.h
+++ b/src/toolbox/tbx/skiplist.h
@@ -59,33 +59,25 @@ TBX_TYPE_INIT(tbx_sl_t, tbx_sl_init_full, tbx_sl_t * self,
                         void (*data_free)(tbx_sl_data_t *a));
 
 // Functions
-TBX_API void tbx_sl_empty(tbx_sl_t *sl);
-
-TBX_API int tbx_sl_insert(tbx_sl_t *sl, tbx_sl_key_t *key, tbx_sl_data_t *data);
-
-TBX_API tbx_sl_iter_t tbx_sl_iter_search_compare(tbx_sl_t *sl, tbx_sl_key_t *key, tbx_sl_compare_t *compare, int round_mode);
-
-TBX_API int tbx_sl_next(tbx_sl_iter_t *it, tbx_sl_key_t **nkey, tbx_sl_data_t **ndata);
-
-TBX_API int tbx_sl_remove(tbx_sl_t *sl, tbx_sl_key_t *key, tbx_sl_data_t *data);
-
-TBX_API tbx_sl_data_t *tbx_sl_search_compare(tbx_sl_t *sl, tbx_sl_key_t *key, tbx_sl_compare_t *compare);
-
-TBX_API tbx_sl_key_t *tbx_sl_first_key(tbx_sl_t *sl);
-
-TBX_API int tbx_sl_key_count(tbx_sl_t *sl);
-
-TBX_API tbx_sl_key_t *tbx_sl_key_last(tbx_sl_t *sl);
-
-TBX_API void tbx_sl_set_strncmp(tbx_sl_compare_t *compare, int n);
-
-TBX_API void tbx_sl_free_no_data(tbx_sl_data_t *data);
-
-TBX_API void tbx_sl_free_no_key(tbx_sl_key_t *key);
-
-TBX_API void tbx_sl_free_simple(tbx_sl_data_t *data);
-
 TBX_API tbx_sl_key_t *tbx_sl_dup_string(tbx_sl_key_t *key);
+TBX_API void tbx_sl_empty(tbx_sl_t *sl);
+TBX_API tbx_sl_key_t *tbx_sl_first_key(tbx_sl_t *sl);
+TBX_API void tbx_sl_free_no_data(tbx_sl_data_t *data);
+TBX_API void tbx_sl_free_no_key(tbx_sl_key_t *key);
+TBX_API void tbx_sl_free_simple(tbx_sl_data_t *data);
+TBX_API int tbx_sl_insert(tbx_sl_t *sl, tbx_sl_key_t *key, tbx_sl_data_t *data);
+TBX_API tbx_sl_iter_t tbx_sl_iter_search_compare(tbx_sl_t *sl,
+                                                 tbx_sl_key_t *key,
+                                                 tbx_sl_compare_t *compare,
+                                                 int round_mode);
+TBX_API int tbx_sl_key_count(tbx_sl_t *sl);
+TBX_API tbx_sl_key_t *tbx_sl_key_last(tbx_sl_t *sl);
+TBX_API int tbx_sl_next(tbx_sl_iter_t *it, tbx_sl_key_t **nkey,
+                        tbx_sl_data_t **ndata);
+TBX_API int tbx_sl_remove(tbx_sl_t *sl, tbx_sl_key_t *key, tbx_sl_data_t *data);
+TBX_API tbx_sl_data_t *tbx_sl_search_compare(tbx_sl_t *sl, tbx_sl_key_t *key,
+                                                tbx_sl_compare_t *compare);
+TBX_API void tbx_sl_set_strncmp(tbx_sl_compare_t *compare, int n);
 
 TBX_API extern tbx_sl_compare_t tbx_sl_compare_int;
 

--- a/src/toolbox/tbx/stack.h
+++ b/src/toolbox/tbx/stack.h
@@ -30,19 +30,19 @@ typedef struct tbx_stack_ele_t tbx_stack_ele_t;
 typedef struct tbx_stack_t tbx_stack_t;
 
 // Functions
-TBX_API int tbx_delete_current(tbx_stack_t *stack, int mv_up, int data_also);
+TBX_API int tbx_stack_delete_current(tbx_stack_t *stack, int mv_up, int data_also);
 
-TBX_API void tbx_dup_stack(tbx_stack_t *new, tbx_stack_t *old);
+TBX_API void tbx_stack_dup(tbx_stack_t *new, tbx_stack_t *old);
 
 TBX_API void tbx_stack_empty(tbx_stack_t *stack, int data_also);
 
-TBX_API void tbx_free_stack(tbx_stack_t *stack, int data_also);
+TBX_API void tbx_stack_free(tbx_stack_t *stack, int data_also);
 
-TBX_API void *tbx_get_ele_data(tbx_stack_t *stack);
+TBX_API void *tbx_stack_get_current_data(tbx_stack_t *stack);
 
-TBX_API tbx_stack_ele_t *tbx_get_ptr(tbx_stack_t *stack);
+TBX_API tbx_stack_ele_t *tbx_stack_get_current_ptr(tbx_stack_t *stack);
 
-TBX_API void *tbx_get_stack_ele_data(tbx_stack_ele_t *ele);
+TBX_API void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele);
 
 TBX_API void tbx_stack_init(tbx_stack_t *stack);
 
@@ -50,7 +50,7 @@ TBX_API int tbx_stack_insert_above(tbx_stack_t *stack, void *data);
 
 TBX_API int tbx_stack_insert_below(tbx_stack_t *stack, void *data);
 
-TBX_API int tbx_stack_insert_link_above(tbx_stack_t *stack, tbx_stack_ele_t *ele);
+TBX_API int tbx_stack_link_insert_above(tbx_stack_t *stack, tbx_stack_ele_t *ele);
 
 TBX_API int tbx_stack_move_down(tbx_stack_t *stack);
 
@@ -68,15 +68,15 @@ TBX_API void *tbx_stack_pop(tbx_stack_t *stack);
 
 TBX_API void tbx_stack_push(tbx_stack_t *stack, void *data);
 
-TBX_API void tbx_push_link(tbx_stack_t *stack, tbx_stack_ele_t *ele);
+TBX_API void tbx_stack_link_push(tbx_stack_t *stack, tbx_stack_ele_t *ele);
 
 TBX_API int tbx_stack_size(tbx_stack_t *stack);
 
 TBX_API tbx_stack_ele_t *tbx_stack_unlink_current(tbx_stack_t *stack, int mv_up);
 
-TBX_API void *tbx_stack_ele_data_get(tbx_stack_ele_t *ele);
+TBX_API void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele);
 
-TBX_API tbx_stack_ele_t *tbx_stack_ele_down_get(tbx_stack_ele_t * stack);
+TBX_API tbx_stack_ele_t *tbx_stack_ele_get_down(tbx_stack_ele_t * stack);
 
 TBX_API tbx_stack_ele_t *tbx_stack_top_get(tbx_stack_t * stack);
 

--- a/src/toolbox/tbx/stack.h
+++ b/src/toolbox/tbx/stack.h
@@ -19,6 +19,7 @@
 #define ACCRE_STACK_H_INCLUDED
 
 #include "tbx/toolbox_visibility.h"
+#include "tbx/tbx_decl.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,58 +28,31 @@ extern "C" {
 // Types
 typedef struct tbx_stack_ele_t tbx_stack_ele_t;
 
-typedef struct tbx_stack_t tbx_stack_t;
+TBX_TYPE(tbx_stack_t, tbx_stack);
 
 // Functions
+TBX_API int tbx_stack_count(tbx_stack_t *stack);
 TBX_API int tbx_stack_delete_current(tbx_stack_t *stack, int mv_up, int data_also);
-
 TBX_API void tbx_stack_dup(tbx_stack_t *new, tbx_stack_t *old);
-
-TBX_API void tbx_stack_empty(tbx_stack_t *stack, int data_also);
-
-TBX_API void tbx_stack_free(tbx_stack_t *stack, int data_also);
-
-TBX_API void *tbx_stack_get_current_data(tbx_stack_t *stack);
-
-TBX_API tbx_stack_ele_t *tbx_stack_get_current_ptr(tbx_stack_t *stack);
-
 TBX_API void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele);
-
-TBX_API void tbx_stack_init(tbx_stack_t *stack);
-
-TBX_API int tbx_stack_insert_above(tbx_stack_t *stack, void *data);
-
-TBX_API int tbx_stack_insert_below(tbx_stack_t *stack, void *data);
-
-TBX_API int tbx_stack_link_insert_above(tbx_stack_t *stack, tbx_stack_ele_t *ele);
-
-TBX_API int tbx_stack_move_down(tbx_stack_t *stack);
-
-TBX_API int tbx_stack_move_to_bottom(tbx_stack_t *stack);
-
-TBX_API int tbx_stack_move_to_ptr(tbx_stack_t *stack, tbx_stack_ele_t *ptr);
-
-TBX_API int tbx_stack_move_to_top(tbx_stack_t *stack);
-
-TBX_API int tbx_stack_move_up(tbx_stack_t *stack);
-
-TBX_API tbx_stack_t *tbx_stack_new();
-
-TBX_API void *tbx_stack_pop(tbx_stack_t *stack);
-
-TBX_API void tbx_stack_push(tbx_stack_t *stack, void *data);
-
-TBX_API void tbx_stack_link_push(tbx_stack_t *stack, tbx_stack_ele_t *ele);
-
-TBX_API int tbx_stack_size(tbx_stack_t *stack);
-
-TBX_API tbx_stack_ele_t *tbx_stack_unlink_current(tbx_stack_t *stack, int mv_up);
-
-TBX_API void *tbx_stack_ele_get_data(tbx_stack_ele_t *ele);
-
 TBX_API tbx_stack_ele_t *tbx_stack_ele_get_down(tbx_stack_ele_t * stack);
-
-TBX_API tbx_stack_ele_t *tbx_stack_top_get(tbx_stack_t * stack);
+TBX_API void tbx_stack_empty(tbx_stack_t *stack, int data_also);
+TBX_API void tbx_stack_free(tbx_stack_t *stack, int data_also);
+TBX_API void *tbx_stack_get_current_data(tbx_stack_t *stack);
+TBX_API tbx_stack_ele_t *tbx_stack_get_current_ptr(tbx_stack_t *stack);
+TBX_API tbx_stack_ele_t *tbx_stack_get_top(tbx_stack_t * stack);
+TBX_API int tbx_stack_insert_above(tbx_stack_t *stack, void *data);
+TBX_API int tbx_stack_insert_below(tbx_stack_t *stack, void *data);
+TBX_API int tbx_stack_link_insert_above(tbx_stack_t *stack, tbx_stack_ele_t *ele);
+TBX_API void tbx_stack_link_push(tbx_stack_t *stack, tbx_stack_ele_t *ele);
+TBX_API int tbx_stack_move_down(tbx_stack_t *stack);
+TBX_API int tbx_stack_move_to_bottom(tbx_stack_t *stack);
+TBX_API int tbx_stack_move_to_ptr(tbx_stack_t *stack, tbx_stack_ele_t *ptr);
+TBX_API int tbx_stack_move_to_top(tbx_stack_t *stack);
+TBX_API int tbx_stack_move_up(tbx_stack_t *stack);
+TBX_API void *tbx_stack_pop(tbx_stack_t *stack);
+TBX_API void tbx_stack_push(tbx_stack_t *stack, void *data);
+TBX_API tbx_stack_ele_t *tbx_stack_unlink_current(tbx_stack_t *stack, int mv_up);
 
 // TEMPORARY
 #if !defined toolbox_EXPORTS && defined LSTORE_HACK_EXPORT

--- a/src/toolbox/tbx/string_token.h
+++ b/src/toolbox/tbx/string_token.h
@@ -27,25 +27,27 @@ extern "C" {
 
 // Functions
 TBX_API char *tbx_stk_argv2format(char *arg);
-
 TBX_API char *tbx_stk_escape_strchr(char escape_char, char *data, char match);
-
-TBX_API char *tbx_stk_escape_string_token(char *str, const char *delims, char escape_char, int compress_delims, char **last, int *finished);
-
-TBX_API char *tbx_stk_escape_text(char *special_chars, char escape_char, char *data);
-
-TBX_API char *tbx_stk_pretty_print_double_with_scale(int base, double value, char *buffer);
-
+TBX_API char *tbx_stk_escape_string_token(char *str,
+                                            const char *delims,
+                                            char escape_char,
+                                            int compress_delims,
+                                            char **last,
+                                            int *finished);
+TBX_API char *tbx_stk_escape_text(char *special_chars,
+                                    char escape_char,
+                                    char *data);
+TBX_API char *tbx_stk_pretty_print_double_with_scale(int base,
+                                                        double value,
+                                                        char *buffer);
 TBX_API char *tbx_stk_pretty_print_int_with_scale(int64_t value, char *buffer);
-
 TBX_API double tbx_stk_string_get_double(char *value);
-
 TBX_API int64_t tbx_stk_string_get_integer(char *value);
-
-TBX_API char *tbx_stk_string_token(char *str, const char *sep, char **last, int *finished);
-
+TBX_API char *tbx_stk_string_token(char *str,
+                                    const char *sep,
+                                    char **last,
+                                    int *finished);
 TBX_API char *tbx_stk_string_trim(char *str);
-
 TBX_API char *tbx_stk_unescape_text(char escape_char, char *data);
 
 #ifdef __cplusplus

--- a/src/toolbox/tbx/tbx_decl.h
+++ b/src/toolbox/tbx/tbx_decl.h
@@ -33,7 +33,7 @@
     TBX_API void FUNCNAME ## _del(); \
     TBX_API TBX_NONNULL int FUNCNAME ## _init(TYPENAME * self); \
     TBX_API void FUNCNAME ## _fini(TYPENAME * self); \
-    TBX_API size_t FUNCNAME ## _size()
+    TBX_API size_t FUNCNAME ## _sizeof()
 
 #define TBX_TYPE_INIT(TYPENAME, FUNCNAME, ...) \
     TBX_API TBX_NONNULL_SOME(1) int FUNCNAME(__VA_ARGS__)
@@ -41,6 +41,40 @@
 #define TBX_TYPE_NEW(TYPENAME, FUNCNAME, ...) \
     TBX_API TBX_MALLOC TYPENAME * FUNCNAME(__VA_ARGS__)
 
+#define TBX_TYPE_NEW_DEFAULT(TYPENAME, FUNCNAME) \
+    TYPENAME * FUNCNAME ## _new() { \
+        TYPENAME * self = malloc(sizeof(TYPENAME)); \
+        if (!self) { \
+            return NULL; \
+        } \
+        int ret = FUNCNAME ## _init(self); \
+        if (ret) { \
+            FUNCNAME ## _del(); \
+            return NULL; \
+        } \
+        return self; \
+    }
+
+#define TBX_TYPE_DEL_DEFAULT(TYPENAME, FUNCNAME) \
+    void FUNCNAME ## _del(TYPENAME * self) { \
+        if (self) { \
+            free(self); \
+        } \
+    }
+
+#define TBX_TYPE_INIT_DEFAULT(TYPENAME, FUNCNAME) \
+    int FUNCNAME ## _init(TYPENAME * self) { \
+        memset((void *) self, 0, FUNCNAME ## _sizeof()); \
+        return 0; \
+    }
+
+#define TBX_TYPE_FINI_DEFAULT(TYPENAME, FUNCNAME) \
+    void FUNCNAME ## _fini(TYPENAME * self) { }
+
+#define TBX_TYPE_SIZEOF_DEFAULT(TYPENAME, FUNCNAME) \
+    size_t FUNCNAME ## _sizeof() { \
+        return sizeof(TYPENAME); \
+    }
 
 #ifdef __GNUC__
 #   define TBX_NONNULL __attribute__((nonnull))

--- a/src/toolbox/tbx/transfer_buffer.h
+++ b/src/toolbox/tbx/transfer_buffer.h
@@ -37,31 +37,29 @@ typedef struct tbx_tbuf_t tbx_tbuf_t;
 typedef struct tbx_tbuf_var_t tbx_tbuf_var_t;
 
 // Functions
-TBX_API int tbx_tbuf_copy(tbx_tbuf_t *tb_s, size_t off_s, tbx_tbuf_t *tb_d, size_t off_d, size_t nbytes, int blank_missing);
-
-TBX_API void tbx_tbuf_fn(tbx_tbuf_t *tb, size_t total_bytes, void *arg, int (*next_block)(tbx_tbuf_t *tb, size_t pos, tbx_tbuf_var_t *tbv));
-
-TBX_API int tbx_tbuf_memset(tbx_tbuf_t *tb, size_t off, int c, size_t nbytes);
-
-TBX_API void tbx_tbuf_single(tbx_tbuf_t *tb, size_t nbytes, char *buffer);
-
-TBX_API size_t tbx_tbuf_size(tbx_tbuf_t *tb);
-
-TBX_API void tbx_tbuf_vec(tbx_tbuf_t *tb, size_t total_bytes, size_t n_vec, tbx_iovec_t *iov);
-
-TBX_API int tbx_tbuf_test();
-
-TBX_API size_t tbx_tbuf_var_size();
-
-TBX_API int tbx_tbuf_next_block(tbx_tbuf_t *tb, size_t off, tbx_tbuf_var_t *tbv);
-
 TBX_API tbx_iovec_t * tbx_tbuf_var_buffer_get(tbx_tbuf_var_t *tbv);
-
-TBX_API int tbx_tbuf_var_n_iov_get(tbx_tbuf_var_t *tbv);
-
-TBX_API void tbx_tbuf_var_nbytes_set(tbx_tbuf_var_t *tbv, size_t nbytes);
-
+TBX_API int tbx_tbuf_copy(tbx_tbuf_t *tb_s, size_t off_s, tbx_tbuf_t *tb_d,
+                            size_t off_d, size_t nbytes, int blank_missing);
+TBX_API void tbx_tbuf_fn(tbx_tbuf_t *tb, size_t total_bytes, void *arg,
+                            int (*next_block)(tbx_tbuf_t *tb,
+                                                size_t pos,
+                                                tbx_tbuf_var_t *tbv));
+TBX_API int tbx_tbuf_memset(tbx_tbuf_t *tb, size_t off, int c, size_t nbytes);
 TBX_API int tbx_tbuf_next(tbx_tbuf_t *tb, size_t off, tbx_tbuf_var_t *tbv);
+TBX_API int tbx_tbuf_next_block(tbx_tbuf_t *tb,
+                                size_t off,
+                                tbx_tbuf_var_t *tbv);
+TBX_API void tbx_tbuf_single(tbx_tbuf_t *tb, size_t nbytes, char *buffer);
+TBX_API size_t tbx_tbuf_size(tbx_tbuf_t *tb);
+TBX_API int tbx_tbuf_test();
+TBX_API int tbx_tbuf_var_n_iov_get(tbx_tbuf_var_t *tbv);
+TBX_API void tbx_tbuf_var_nbytes_set(tbx_tbuf_var_t *tbv, size_t nbytes);
+TBX_API size_t tbx_tbuf_var_size();
+TBX_API void tbx_tbuf_vec(tbx_tbuf_t *tb,
+                            size_t total_bytes,
+                            size_t n_vec,
+                            tbx_iovec_t *iov);
+
 // Preprocessor macros
 #define TBUFFER_OK 1
 #define TBUFFER_OUTOFSPACE 2

--- a/src/toolbox/transfer_buffer.c
+++ b/src/toolbox/transfer_buffer.c
@@ -125,15 +125,15 @@ int tb_next_block(tbx_tbuf_t *tb, size_t pos, tbx_tbuf_var_t *tbv)
         tbv->priv.curr_slot = 0;
     }
 //log_printf(15, "tb_next_block: start slot=%d total_slots=%d iov[0]=%p\n", tbv->priv.curr_slot, ti->n, v);
-//tbx_flush_log();
+//tbx_log_flush();
 
 //dn = v[0].iov_len;
-//log_printf(15, "tb_next_block: v[0].len=%d\n", dn); tbx_flush_log();
+//log_printf(15, "tb_next_block: v[0].len=%d\n", dn); tbx_log_flush();
 
     slot = tbv->priv.curr_slot;
     for (i=tbv->priv.curr_slot; i<ti->n; i++) {
 //dn = v[i].iov_len;
-//log_printf(15, "tb_next_block: i=%d len=%d\n", i, dn); tbx_flush_log();
+//log_printf(15, "tb_next_block: i=%d len=%d\n", i, dn); tbx_log_flush();
         ds = sum + v[i].iov_len;
         if (ds > pos) {
             slot = i;
@@ -295,7 +295,7 @@ int tbx_tbuf_copy(tbx_tbuf_t *tb_s, size_t off_s, tbx_tbuf_t *tb_d, size_t off_d
                 while (n > 0) {
                     len = (slen_ele > dlen_ele) ? dlen_ele : slen_ele;
                     if ((dtv.buffer[di].iov_base != NULL) && (stv.buffer[si].iov_base != NULL)) {
-//log_printf(15, "dtv.buffer[%d].iov_base=%p stv.buffer[%d].iov_base=%p\n", di, dtv.buffer[di].iov_base, si, stv.buffer[si].iov_base); tbx_flush_log();
+//log_printf(15, "dtv.buffer[%d].iov_base=%p stv.buffer[%d].iov_base=%p\n", di, dtv.buffer[di].iov_base, si, stv.buffer[si].iov_base); tbx_log_flush();
                         memcpy(dtv.buffer[di].iov_base+dp_ele, stv.buffer[si].iov_base+sp_ele, len);
                     } else {
                         log_printf(15, "ERROR dtv.buffer[%d].iov_base=%p stv.buffer[%d].iov_base=%p\n", di, dtv.buffer[di].iov_base, si, stv.buffer[si].iov_base);
@@ -413,7 +413,7 @@ int tbx_tbuf_test_read(tbx_tbuf_t *tbuf, char *buffer, int bufsize, int off, int
 //log_printf(0, "tbx_tbuf_test_read: after loop n_iov=%d off=%d len=%d bufsize=%d nleft=%d pos=%d opos=%d\n", tv.n_iov, off, len, bufsize, nleft, pos, opos);
     }
 
-//tbx_flush_log();
+//tbx_log_flush();
 
     err = memcmp(&(buffer[off]), output, len);
     if (err != 0) {
@@ -459,7 +459,7 @@ int tbuffer_next_test_iovec(int n_iovec, int n_random, char *buffer, int bufsize
         frac = (i+1.0)/(n_iovec*1.0);
         maxlen = frac*bufsize - off;
 //log_printf(0, "tbuffer_next_text_iovec: n_iovec=%d i=%d frac=%lf maxlen=%d\n", n_iovec, i, frac,maxlen);
-        len = tbx_random_int64(0, maxlen);
+        len = tbx_random_get_int64(0, maxlen);
         iov[i].iov_base = &(buffer[off]);
         iov[i].iov_len = len;
         off += len;
@@ -485,8 +485,8 @@ int tbuffer_next_test_iovec(int n_iovec, int n_random, char *buffer, int bufsize
 
     //** Now do the random offset/len tests
     for (i=0; i<n_random; i++) {
-        off = tbx_random_int64(0, bufsize);
-        len = tbx_random_int64(0, bufsize - off);
+        off = tbx_random_get_int64(0, bufsize);
+        len = tbx_random_get_int64(0, bufsize - off);
         err = tbx_tbuf_test_read(&tbuf, buffer, bufsize, off, len);
         if (err != 0) {
             log_printf(0, "tbuffer_next_test_iovec: Error with random read: n_iovec=%d off=%d len=%d\n", n_iovec, off, len);
@@ -546,7 +546,7 @@ int tbuffer_copy_test_iovec(int n1_iovec, int n2_iovec, int n_random, char *buff
     for (i=0; i<n1_iovec; i++) {
         frac = (i+1.0)/(n1_iovec*1.0);
         maxlen = frac*bufsize - off1;
-        len = tbx_random_int64(0, maxlen);
+        len = tbx_random_get_int64(0, maxlen);
         iov1[i].iov_base = &(buffer[off1]);
         iov1[i].iov_len = len;
         off1 += len;
@@ -568,7 +568,7 @@ int tbuffer_copy_test_iovec(int n1_iovec, int n2_iovec, int n_random, char *buff
     for (i=0; i<n2_iovec; i++) {
         frac = (i+1.0)/(n2_iovec*1.0);
         maxlen = frac*bufsize - off2;
-        len = tbx_random_int64(0, maxlen);
+        len = tbx_random_get_int64(0, maxlen);
         iov2[i].iov_base = &(output[off2]);
         iov2[i].iov_len = len;
         off2 += len;
@@ -597,10 +597,10 @@ int tbuffer_copy_test_iovec(int n1_iovec, int n2_iovec, int n_random, char *buff
 
     //** Now do the random offset/len tests
     for (i=0; i<n_random; i++) {
-        off1 = tbx_random_int64(0, bufsize);
-        off2 = tbx_random_int64(0, bufsize);
+        off1 = tbx_random_get_int64(0, bufsize);
+        off2 = tbx_random_get_int64(0, bufsize);
         len = (off1 > off2) ?  bufsize - off1 : bufsize - off2;
-        len = tbx_random_int64(0, len);
+        len = tbx_random_get_int64(0, len);
         memset(output, '-', bufsize);
         output[bufsize] = 0;
         tbx_tbuf_copy(&tbuf1, 0, &tbuf2, 0, bufsize, 1);

--- a/test/fuzz-config.c
+++ b/test/fuzz-config.c
@@ -20,7 +20,7 @@
 #include <tbx/iniparse.h>
 
 int main(int argc, char **argv) {
-    tbx_inip_file_t *ini = tbx_inip_file_read("-");
+    tbx_inip_file_t *ini = tbx_inip_read_file("-");
     tbx_inip_destroy(ini);
     return 0;
 }

--- a/test/fuzz-config.c
+++ b/test/fuzz-config.c
@@ -20,7 +20,7 @@
 #include <tbx/iniparse.h>
 
 int main(int argc, char **argv) {
-    tbx_inip_file_t *ini = tbx_inip_read_file("-");
+    tbx_inip_file_t *ini = tbx_inip_file_read("-");
     tbx_inip_destroy(ini);
     return 0;
 }

--- a/test/test-tb-stack.c
+++ b/test/test-tb-stack.c
@@ -13,7 +13,7 @@ TEST_IMPL(tb_stack) {
     NOTE("STACK");
     ASSERT(tbx_stack_get_current_data(stack) == NULL);
     NOTE("STACK");
-    ASSERT(tbx_stack_size(stack) == 0);
+    ASSERT(tbx_stack_count(stack) == 0);
     NOTE("STACK");
     
     tbx_stack_empty(stack, 0);

--- a/test/test-tb-stack.c
+++ b/test/test-tb-stack.c
@@ -9,9 +9,9 @@ TEST_IMPL(tb_stack) {
     NOTE("STACK");
     ASSERT(stack != 0);
     NOTE("STACK");
-    ASSERT(tbx_get_ptr(stack) == NULL);
+    ASSERT(tbx_stack_get_current_ptr(stack) == NULL);
     NOTE("STACK");
-    ASSERT(tbx_get_ele_data(stack) == NULL);
+    ASSERT(tbx_stack_get_current_data(stack) == NULL);
     NOTE("STACK");
     ASSERT(tbx_stack_size(stack) == 0);
     NOTE("STACK");
@@ -31,9 +31,9 @@ TEST_IMPL(tb_stack) {
     ASSERT(stack2 != 0);
     NOTE("STACK");
 
-    tbx_free_stack(stack, 1);
+    tbx_stack_free(stack, 1);
     NOTE("STACK");
-    tbx_free_stack(stack2, 1);
+    tbx_stack_free(stack2, 1);
     NOTE("STACK");
     
     return 0;


### PR DESCRIPTION
Go through and rename toolbox functions to have regular naming scheme. e.g.: `tbx_stack_get_top` not `tbx_stack_top_get`. Migrate remaining "class-like" structs to using the common interface defined in tbx/tbx_decl.h
