### PR TITLE
Fix resource leak in checksumming

### DIFF
--- a/src/toolbox/chksum.c
+++ b/src/toolbox/chksum.c
@@ -180,9 +180,9 @@ int cipher ## _add(void *state, int nbytes, tbx_tbuf_t *data, int boff)   \
             free(tbv); \
             return(err);               \
         } \
-    }                                             \
+    }                                              \
   }                                                \
-                                                   \
+  free(tbv);                                       \
   return(err);                                     \
 }                                                  \
                                                    \


### PR DESCRIPTION
Should solve coverity 105193, 105192, 105189, 105188
(is there a way to hotlink these?)
