### PR TITLE
Add 1/3 of the toolbox docs

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -2018,7 +2018,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = TBX_API=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/assert.rst
+++ b/doc/assert.rst
@@ -1,0 +1,17 @@
+.. _assert:
+
+Assertion Wrappers
+=======================================
+Wraps some assertion uses for the cases you want to assert on side-effects.
+Declared in `tbx/assert_result.h`
+
+API
+----
+.. doxygendefine:: assert_result
+
+.. doxygendefine:: assert_result_not
+
+.. doxygendefine:: assert_result_not_null
+
+.. doxygendefine:: ASSERT_ALWAYS
+

--- a/doc/dns_cache.rst
+++ b/doc/dns_cache.rst
@@ -1,0 +1,10 @@
+.. _dns_cache:
+
+Caching DNS Resolver
+=======================================
+Performs DNS lookups with an embedded cache. Declared in `tbx/dns_cache.h`
+
+API
+----
+.. doxygenfunction:: tbx_dnsc_lookup
+

--- a/doc/iniparse.rst
+++ b/doc/iniparse.rst
@@ -1,0 +1,35 @@
+.. _iniparse:
+
+iniparse --- INI Configuration Parsing
+========================================
+Configuration parsing library. Declared in `tbx/iniparse.h`
+
+API
+----
+.. doxygenfunction:: tbx_inip_destroy
+.. doxygenfunction:: tbx_inip_ele_first
+.. doxygenfunction:: tbx_inip_ele_get_key
+.. doxygenfunction:: tbx_inip_ele_get_value
+.. doxygenfunction:: tbx_inip_ele_next
+.. doxygenfunction:: tbx_inip_file_read
+.. doxygenfunction:: tbx_inip_find_key
+.. doxygenfunction:: tbx_inip_get_double
+.. doxygenfunction:: tbx_inip_get_integer
+.. doxygenfunction:: tbx_inip_get_string
+.. doxygenfunction:: tbx_inip_group_count
+.. doxygenfunction:: tbx_inip_group_find
+.. doxygenfunction:: tbx_inip_group_first
+.. doxygenfunction:: tbx_inip_group_free
+.. doxygenfunction:: tbx_inip_group_get
+.. doxygenfunction:: tbx_inip_group_next
+.. doxygenfunction:: tbx_inip_group_set
+.. doxygenfunction:: tbx_inip_string_read
+
+Typedefs
+--------
+.. doxygentypedef:: tbx_inip_element_t
+
+.. doxygentypedef:: tbx_inip_file_t
+
+.. doxygentypedef:: tbx_inip_group_t
+

--- a/doc/toolbox.rst
+++ b/doc/toolbox.rst
@@ -5,6 +5,7 @@ Contents:
 
 .. toctree::
     :maxdepth: 1
-    
+
+    assert
     checksum
 

--- a/doc/toolbox.rst
+++ b/doc/toolbox.rst
@@ -8,4 +8,5 @@ Contents:
 
     assert
     checksum
+    dns_cache
 

--- a/doc/toolbox.rst
+++ b/doc/toolbox.rst
@@ -9,4 +9,4 @@ Contents:
     assert
     checksum
     dns_cache
-
+    iniparse

--- a/src/toolbox/dns_cache.c
+++ b/src/toolbox/dns_cache.c
@@ -57,6 +57,8 @@ typedef struct {
 } DNS_cache_t;
 
 DNS_cache_t *_cache = NULL;
+// Forward declaration
+int tbx_dnsc_startup_sized(int size);
 
 
 //**************************************************************************

--- a/src/toolbox/tbx/assert_result.h
+++ b/src/toolbox/tbx/assert_result.h
@@ -20,15 +20,38 @@
 
 #include <assert.h>
 
+/*! \file
+ * Wrap assert to support side-effects. This is a temporary utility while we
+ * remove those cases
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // Preprocessor macros
 #ifndef NDEBUG
-#define assert_result(eval_this, expected_result) assert((eval_this) == expected_result)
+/*! \brief Evaluates an expression. If assertions are enabled, assert the result
+ *         is equal to the result
+ *  @param eval_this Expression to evaluate
+ *  @param result Desired result of expression
+ */
+#define assert_result(eval_this, result) assert((eval_this) == result)
+/*! \brief Evaluates an expression. If assertions are enabled, assert the result
+ *         is not equal to the result
+ *  @param eval_this Expression to evaluate
+ *  @param result Undesired result of expression
+ */
 #define assert_result_not(eval_this, result) assert((eval_this) != result)
+/*! \brief Evaluates an expression. If assertions are enabled, assert the result
+ *         is not NULL
+ *  @param eval_this Expression to evaluate
+ */
 #define assert_result_not_null(eval_this) assert((eval_this) != NULL)
+/*! \brief Always evaluate an expression. Perform an assertion if asserts are
+ *         enabled
+ *  @param expr Expression to evaluate and possibly assert
+ */
 #define ASSERT_ALWAYS(expr) assert(expr)
 #else
 #define assert_result(eval_this, expected_result) (eval_this)

--- a/src/toolbox/tbx/dns_cache.h
+++ b/src/toolbox/tbx/dns_cache.h
@@ -14,6 +14,10 @@
    limitations under the License.
 */
 
+/*! \file
+ * Wrappers for cached DNS resolution
+ */
+
 #pragma once
 #ifndef ACCRE_DNS_CACHE_H_INCLUDED
 #define ACCRE_DNS_CACHE_H_INCLUDED
@@ -25,10 +29,21 @@ extern "C" {
 #endif
 
 // Functions
+/*! \brief Resolve a hostname via DNS, caching results
+ *  \param name Hostname to resolve
+ *  \param byte_addr Resulting IP address in binary form
+ *  \param ip_addr Resulting IP address in text form
+ *  \return Zero on success
+ *
+ *  The caller is responsible for freeing ip_addr and byte_addr
+ */
 TBX_API int tbx_dnsc_lookup(const char * name, char * byte_addr, char * ip_addr);
+/*! @brief Performs global initialization. Called automatically on startup
+ */
 TBX_API int tbx_dnsc_shutdown();
+/*! @brief Performs global deinitialization. Called automatically on shutdown
+ */
 TBX_API int tbx_dnsc_startup();
-TBX_API int tbx_dnsc_startup_sized(int size);
 
 // Preprocessor macros
 #define DNS_ADDR_MAX 4

--- a/src/toolbox/tbx/iniparse.h
+++ b/src/toolbox/tbx/iniparse.h
@@ -14,6 +14,10 @@
    limitations under the License.
 */
 
+/*! \file
+ * Configuration parsing
+ */
+
 #pragma once
 #ifndef ACCRE_INIPARSE_H_INCLUDED
 #define ACCRE_INIPARSE_H_INCLUDED
@@ -26,10 +30,13 @@ extern "C" {
 #endif
 
 // Types
+/*! A single configuration value (opaque) */
 typedef struct tbx_inip_element_t tbx_inip_element_t;
 
+/*! Parsed configuration object (opaque) */
 typedef struct tbx_inip_file_t tbx_inip_file_t;
 
+/*! Configuration group which contains many elements (opaque) */
 typedef struct tbx_inip_group_t tbx_inip_group_t;
 
 // Functions


### PR DESCRIPTION
My share of the documentation that needs to be added:

The other two will add the doxygen and sphinx bits for the other 2/3rds.

```
toolbox/tbx/assert_result.h
toolbox/tbx/dns_cache.h
toolbox/tbx/iniparse.h
toolbox/tbx/list.h
toolbox/tbx/network.h
toolbox/tbx/skiplist.h
toolbox/tbx/stack.h
toolbox/tbx/string_token.h
toolbox/tbx/varint.h
```
