### PR TITLE
Second round of coverity fixes

### DIFF
--- a/src/toolbox/iniparse.c
+++ b/src/toolbox/iniparse.c
@@ -547,6 +547,15 @@ tbx_inip_file_t *tbx_inip_file_read(const char *fname)
 
 tbx_inip_file_t *tbx_inip_string_read(const char *text)
 {
+    /* POSIX requires mkstemp sets the permissions of the resulting file to
+     * 0600. Coverity assumes the much broader stance that mkstemp is influenced
+     * by the current umask, so it complains that you need to set umask to 0000
+     * before calling mkstemp. It doesn't really make sense anyway, you can't
+     * safely set umask in a multithreaded application. Sinec it's only obscure
+     * versions of libc that have the other behavior, just tell coverity to
+     * ignore it
+     */
+    // coverity[secure_temp]
     int file_temp = mkstemp("tbx_inip_XXXXXX");
     if (file_temp == -1) {
         goto error1;

--- a/src/toolbox/interval_skiplist.c
+++ b/src/toolbox/interval_skiplist.c
@@ -470,6 +470,7 @@ tbx_isl_iter_t tbx_isl_iter_search(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_
     it.isl = isl;
     it.ele = NULL;
     it.sn = NULL;
+    it.isln = NULL;
     it.lo = lo;
     it.hi = hi;
     it.mode = 0;

--- a/src/toolbox/interval_skiplist.c
+++ b/src/toolbox/interval_skiplist.c
@@ -317,8 +317,6 @@ int tbx_isl_insert(tbx_isl_t *isl, tbx_sl_key_t *lo, tbx_sl_key_t *hi, tbx_sl_da
             if ((ptr[i] != NULL) && (ptr[i] != isl->sl->head)) copy_isl_data(((tbx_isl_node_t *)(ptr[i]->ele.data))->edge[i], &(isl_node->edge[i]));
         }
 
-        memset(ptr, 0, sizeof(ptr));
-        find_key(sl, ptr, lo, 0);
     }
 
     isl_node = (tbx_isl_node_t *)(sn->ele.data);


### PR DESCRIPTION
The first pass didn't quite get everything. Sort out the remainder for the next time coverity runs.
