### PR TITLE
Support relocatable tarball building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,12 @@ project(LStore C)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(LStoreVersion)
 
+# Use gnu-style paths
+include(GNUInstallDirs)
+
+# Setting RPATH lets us have relocatable tarballs
+set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+
 # Defines
 set(USE_SUPERBUILD ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -D_REENTRANT -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -fvisibility=hidden -fno-strict-aliasing -Wall -Wextra -Werror -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=sign-compare")
@@ -196,8 +202,6 @@ set(LSTORE_CHEAT_FLAGS "-Wno-error=unused-variable -Wno-error=array-bounds ${LST
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${LSTORE_CHEAT_FLAGS}")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${LSTORE_CHEAT_FLAGS}")
 
-# Use gnu-style paths
-include(GNUInstallDirs)
 
 # Find external deps we don't build
 find_package(OpenSSL REQUIRED)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node('docker') {
     zip archive: true, dir: '', glob: 'scripts/**', zipFile: 'scripts.zip'
     archive 'scripts/**'
     stash includes: '**, .git/', name: 'source', useDefaultExcludes: false
-    slackSend channel: 'jenkins', message: 'Build Started - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)'
+    slackSend channel: 'jenkins', message: "Build Started - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
     sh "env"
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,9 +104,14 @@ compile_map['scan-build'] = {
     }
 }
 
-for (int i = 0 ; i < distros.size(); ++i) {
-    def x = distros.get(i)
+@NonCPS def loopArray(a) {
+    a.collect{ v -> v }
+}
+for (def y in loopArray(distros)) {
+    def x = y
+    println "Processing outer ${x}"
     compile_map["${x}"] = { node('docker') {
+        println "Processing inner ${x}"
         deleteDir()
         unstash 'source'
         sh """bash scripts/generate-docker-base.sh ${x}


### PR DESCRIPTION
Setting RPATH on the binaries to $ORIGIN will let us have relocatable
tarballs, so we can ship around our packages more easily