### PR TITLE
Bugfix/zmq getsockopt

### DIFF
--- a/src/gop/mq_portal.c
+++ b/src/gop/mq_portal.c
@@ -1225,9 +1225,9 @@ int mq_conn_make(gop_mq_conn_t *c)
         err = gop_mq_bind(c->sock, c->pc->host);
     }
 
-    size_t s;
+    size_t s = sizeof(c->mq_uuid);
     zmq_getsockopt(c->sock->arg, ZMQ_IDENTITY, &c->mq_uuid, &s);
-    if (s <= 0) c->mq_uuid = "ERROR_GETTING_IDENTITY";
+    if (s <= 0) strncpy(c->mq_uuid, "ERROR_GETTING_IDENTITY", sizeof(c->mq_uuid));
 
     if (err != 0) return(1);
     if (c->pc->connect_mode == MQ_CMODE_SERVER) return(0);  //** Nothing else to do

--- a/src/gop/mq_portal.c
+++ b/src/gop/mq_portal.c
@@ -1226,7 +1226,7 @@ int mq_conn_make(gop_mq_conn_t *c)
     }
 
     size_t s = sizeof(c->mq_uuid);
-    zmq_getsockopt(c->sock->arg, ZMQ_IDENTITY, &c->mq_uuid, &s);
+    zmq_getsockopt(c->sock->arg, ZMQ_IDENTITY, c->mq_uuid, &s);
     if (s <= 0) strncpy(c->mq_uuid, "ERROR_GETTING_IDENTITY", sizeof(c->mq_uuid));
 
     if (err != 0) return(1);

--- a/src/gop/mq_portal.h
+++ b/src/gop/mq_portal.h
@@ -96,7 +96,7 @@ struct gop_mq_task_monitor_t {
 
 struct gop_mq_conn_t {  //** MQ connection container
     gop_mq_portal_t *pc;   //** Parent MQ portal
-    char *mq_uuid;     //** MQ UUID
+    char mq_uuid[255];     //** MQ UUID
     gop_mq_socket_t *sock; //** MQ connection socket
     apr_hash_t *waiting;  //** Tasks waiting for a response (key = task ID)
     apr_hash_t *heartbeat_dest;  //** List of unique destinations for heartbeats (key = tracking address)


### PR DESCRIPTION
Believe it or not having the "&" seems to not make a difference.  Both return the correct UUID and both ASAN and Valgrind are happy