### PR TITLE
Final version before deploying on cluster

### DIFF
--- a/src/gop/mq_helpers.c
+++ b/src/gop/mq_helpers.c
@@ -37,6 +37,27 @@
 static tbx_atomic_unit32_t _id_counter = 0;
 
 //***********************************************************************
+// mq_id_bytes - Returns hte number of bytes for the remote id.
+//     Assumes the host string is of the form: id|tcp://address:port
+//   Returns the number of bytes for the ID
+//***********************************************************************
+
+int mq_id_bytes(char *host, int len)
+{
+    int i;
+
+    if (host == NULL) return(0);
+
+    i = 0;
+    do {
+        if (host[i] == '|') break;
+        i++;
+    } while (i<len);
+
+   return(i);
+}
+
+//***********************************************************************
 // mq_make_id_frame - Makes and generates and ID frame
 //***********************************************************************
 

--- a/src/gop/mq_helpers.h
+++ b/src/gop/mq_helpers.h
@@ -31,7 +31,7 @@ extern "C" {
 gop_mq_frame_t *mq_make_id_frame();
 int mq_num_frames(mq_msg_t *msg);
 char *mq_address_to_string(mq_msg_t *address);
-
+int mq_id_bytes(char *host, int len);
 
 #ifdef __cplusplus
 }

--- a/src/lio/CMakeLists.txt
+++ b/src/lio/CMakeLists.txt
@@ -66,6 +66,7 @@ set(LSTORE_INCLUDE_PUBLIC ${PROJECT_SOURCE_DIR})
 # common objects
 set(LSTORE_PROJECT_OBJS
 		authn/fake.c
+		blacklist.c
 		cache/amp.c
 		cache/base.c
 		cache/round_robin.c

--- a/src/lio/bin/lio_du.c
+++ b/src/lio/bin/lio_du.c
@@ -187,6 +187,11 @@ int main(int argc, char **argv)
         if (rg_mode == 0) {
             //** Create the simple path iterator
             tuple = lio_path_resolve(lio_gc->auto_translate, argv[j]);
+            if (tuple.is_lio < 0) { //** Malformed path
+                fprintf(stderr, "Unable to parse path: %s\n", argv[j]);
+                return_code = EINVAL;
+                continue;
+            }
             lio_path_wildcard_auto_append(&tuple);
             rp_single = lio_os_path_glob2regex(tuple.path);
         } else {

--- a/src/lio/bin/lio_find.c
+++ b/src/lio/bin/lio_find.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tbx/log.h>
-
+#include <tbx/stdinarray_iter.h>
 #include <lio/lio.h>
 #include <lio/os.h>
 
@@ -31,10 +31,11 @@
 
 int main(int argc, char **argv)
 {
-    int i, j, ftype, rg_mode, start_option, start_index, prefix_len, nopre, return_code;
-    char *fname;
+    int i, ftype, rg_mode, start_option, start_index, prefix_len, nopre, return_code;
+    char *fname, *path;
     lio_path_tuple_t tuple;
     lio_os_regex_table_t *rp_single, *ro_single;
+    tbx_stdinarray_iter_t *it_args;
     os_object_iter_t *it = NULL;
 
     int recurse_depth = 10000;
@@ -92,16 +93,20 @@ int main(int argc, char **argv)
         start_index--;  //** Ther 1st entry will be the rp created in lio_parse_path_options
     }
 
-    for (j=start_index; j<argc; j++) {
-        log_printf(5, "path_index=%d argc=%d rg_mode=%d\n", j, argc, rg_mode);
+    it_args = tbx_stdinarray_iter_create(argc-start_index, (const char **)(argv+start_index));
+    while (1) {
         if (rg_mode == 0) {
             //** Create the simple path iterator
-            tuple = lio_path_resolve(lio_gc->auto_translate, argv[j]);
+            path = tbx_stdinarray_iter_next(it_args);
+            if (!path) break;
+            tuple = lio_path_resolve(lio_gc->auto_translate, path);
             if (tuple.is_lio < 0) {  //** Can't resolve path
-                fprintf(stderr, "Unable to resolve path: %s\n", argv[j]);
+                fprintf(stderr, "Unable to resolve path: %s\n", path);
+                free(path);
                 return_code = EINVAL;
                 continue;
             }
+            free(path);
             lio_path_wildcard_auto_append(&tuple);
             rp_single = lio_os_path_glob2regex(tuple.path);
         } else {
@@ -140,6 +145,7 @@ int main(int argc, char **argv)
     }
 
 finished:
+    tbx_stdinarray_iter_destroy(it_args);
     lio_shutdown();
     if (it == NULL) return_code = EIO;
     return(return_code);

--- a/src/lio/bin/lio_getattr.c
+++ b/src/lio/bin/lio_getattr.c
@@ -234,6 +234,11 @@ int main(int argc, char **argv)
         if (rg_mode == 0) {
             //** Create the simple path iterator
             tuple = lio_path_resolve(lio_gc->auto_translate, argv[j]);
+            if (tuple.is_lio < 0) {
+                fprintf(stderr, "Unable to parse path: %s\n", argv[j]);
+                return_code = EINVAL;
+                continue;
+            }
             lio_path_wildcard_auto_append(&tuple);
             rp_single = lio_os_path_glob2regex(tuple.path);
         } else {

--- a/src/lio/bin/lio_inspect.c
+++ b/src/lio/bin/lio_inspect.c
@@ -1435,6 +1435,12 @@ int main(int argc, char **argv)
         if (rg_mode == 0) {
             //** Create the simple path iterator
             tuple = lio_path_resolve(lio_gc->auto_translate, path);
+            if (tuple.is_lio < 0) {
+                fprintf(stderr, "Unable to parse path: %s\n", path);
+                err = EINVAL;
+                free(path);
+                continue;
+            }
             lio_path_wildcard_auto_append(&tuple);
             rp_single = lio_os_path_glob2regex(tuple.path);
             free(path);
@@ -1448,7 +1454,7 @@ int main(int argc, char **argv)
         it = lio_create_object_iter_alist(tuple.lc, tuple.creds, rp_single, ro_single, OS_OBJECT_FILE_FLAG, recurse_depth, keys, (void **)vals, v_size, acount);
         if (it == NULL) {
             info_printf(lio_ifd, 0, "ERROR: Failed with object_iter creation\n");
-            err = 2;
+            err = EIO;
             goto finished;
         }
 
@@ -1595,11 +1601,11 @@ int main(int argc, char **argv)
 
     if (submitted != (good+bad)) {
         info_printf(lio_ifd, 0, "ERROR FAILED self-consistency check! Submitted != Success+Fail\n");
-        err = 2;
+        err = EFAULT;
     }
     if (bad > 0) {
         info_printf(lio_ifd, 0, "ERROR Some files failed inspection!\n");
-        err = 1;
+        err = EIO;
     }
 
 

--- a/src/lio/bin/lio_inspect.c
+++ b/src/lio/bin/lio_inspect.c
@@ -817,7 +817,7 @@ gop_op_status_t inspect_task(void *arg, int id)
 
     //** If we made it here the exnode is unique and loaded.
     //** Load it
-    exp = lio_lio_exnode_exchange_text_parse(w->exnode);
+    exp = lio_exnode_exchange_text_parse(w->exnode);
     if (exp == NULL) {
         info_printf(lfd, 0, "ERROR  Failed with file %s (ftype=%d). Problem parsing exnode!\n", w->fname, w->ftype);
         status = gop_failure_status;

--- a/src/lio/bin/lio_ln.c
+++ b/src/lio/bin/lio_ln.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
     src_fname = argv[i];
     i++;
     stuple = lio_path_resolve(lio_gc->auto_translate, src_fname);
-    if (stuple.is_lio < 0) {                                                                                                                                                   
+    if (stuple.is_lio < 0) {
         fprintf(stderr, "Unable to parse path: %s\n", src_fname);
         return(EINVAL);
     }
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
     dest_fname = argv[i];
     i++;
     dtuple = lio_path_resolve(lio_gc->auto_translate, dest_fname);
-    if (dtuple.is_lio < 0) {                                                                                                                                                   
+    if (dtuple.is_lio < 0) {
         fprintf(stderr, "Unable to parse path: %s\n", dest_fname);
         return(EINVAL);
     }

--- a/src/lio/bin/lio_ln.c
+++ b/src/lio/bin/lio_ln.c
@@ -84,9 +84,18 @@ int main(int argc, char **argv)
     src_fname = argv[i];
     i++;
     stuple = lio_path_resolve(lio_gc->auto_translate, src_fname);
+    if (stuple.is_lio < 0) {                                                                                                                                                   
+        fprintf(stderr, "Unable to parse path: %s\n", src_fname);
+        return(EINVAL);
+    }
+
     dest_fname = argv[i];
     i++;
     dtuple = lio_path_resolve(lio_gc->auto_translate, dest_fname);
+    if (dtuple.is_lio < 0) {                                                                                                                                                   
+        fprintf(stderr, "Unable to parse path: %s\n", dest_fname);
+        return(EINVAL);
+    }
 
     //** Make sure we're linking in the same system
     if (strcmp(stuple.lc->section_name, dtuple.lc->section_name) != 0) {

--- a/src/lio/bin/lio_ls.c
+++ b/src/lio/bin/lio_ls.c
@@ -201,12 +201,16 @@ int main(int argc, char **argv)
     q = gop_opque_new();
     table = tbx_list_create(0, &tbx_list_string_compare, NULL, tbx_list_no_key_free, tbx_list_no_data_free);
 
-
     for (j=start_index; j<argc; j++) {
         log_printf(5, "path_index=%d argc=%d rg_mode=%d\n", j, argc, rg_mode);
         if (rg_mode == 0) {
             //** Create the simple path iterator
             tuple = lio_path_resolve(lio_gc->auto_translate, argv[j]);
+            if (tuple.is_lio < 0) {
+                fprintf(stderr, "Unable to parse path: %s\n", argv[j]);
+                return_code = EINVAL;
+                continue;
+            }
             lio_path_wildcard_auto_append(&tuple);
             rp_single = lio_os_path_glob2regex(tuple.path);
         } else {

--- a/src/lio/bin/lio_put.c
+++ b/src/lio/bin/lio_put.c
@@ -81,6 +81,10 @@ int main(int argc, char **argv)
 
     //** Get the destination
     tuple = lio_path_resolve(lio_gc->auto_translate, argv[start_index]);
+    if (tuple.is_lio < 0) {
+        fprintf(stderr, "Unable to parse path: %s\n", argv[start_index]);
+        return(EINVAL);
+    }
 
     //** Check if it exists and if not create it
     dtype = lio_exists(tuple.lc, tuple.creds, tuple.path);

--- a/src/lio/bin/lio_rm.c
+++ b/src/lio/bin/lio_rm.c
@@ -68,6 +68,7 @@ int main(int argc, char **argv)
     argv_list = argv;
 
     //*** Parse the args
+    return_code = 0;
     rp_single = ro_single = NULL;
 
     rg_mode = lio_parse_path_options(&argc, argv, lio_gc->auto_translate, &tuple, &rp_single, &ro_single);
@@ -119,7 +120,6 @@ int main(int argc, char **argv)
     opque_start_execution(q);
     i = 0;
     loop = 0;
-    return_code = 0;
     while ((path = tbx_stdinarray_iter_next(piter)) != NULL) {
         loop++;
         path_list[i] = path;

--- a/src/lio/bin/lio_setattr.c
+++ b/src/lio/bin/lio_setattr.c
@@ -188,6 +188,11 @@ int main(int argc, char **argv)
         if (rg_mode == 0) {
             //** Create the simple path iterator
             tuple = lio_path_resolve(lio_gc->auto_translate, argv[j]);
+            if (tuple.is_lio < 0) {
+                fprintf(stderr, "Unable to parse path: %s\n", argv[j]);
+                return_code = EINVAL;
+                continue;
+            }
             rp_single = lio_os_path_glob2regex(tuple.path);
         } else {
             rg_mode = 0;  //** Use the initial rp

--- a/src/lio/bin/lio_signature.c
+++ b/src/lio/bin/lio_signature.c
@@ -60,6 +60,10 @@ int main(int argc, char **argv)
 
     //** Get the source
     tuple = lio_path_resolve(lio_gc->auto_translate, argv[start_index]);
+    if (tuple.is_lio < 0) {
+        fprintf(stderr, "Unable to parse path: %s\n", argv[start_index]);
+        return(EINVAL);
+    }
 
     //** Check if it exists
     ftype = lio_exists(tuple.lc, tuple.creds, tuple.path);

--- a/src/lio/bin/lio_signature.c
+++ b/src/lio/bin/lio_signature.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     }
 
     //** Load it
-    exp = lio_lio_exnode_exchange_text_parse(ex_data);
+    exp = lio_exnode_exchange_text_parse(ex_data);
     ex = lio_exnode_create();
     if (lio_exnode_deserialize(ex, exp, tuple.lc->ess) != 0) {
         info_printf(lio_ifd, 0, "No default segment!  Aborting!\n");

--- a/src/lio/bin/lio_touch.c
+++ b/src/lio/bin/lio_touch.c
@@ -28,6 +28,7 @@
 #include <tbx/assert_result.h>
 #include <tbx/list.h>
 #include <tbx/log.h>
+#include <tbx/stdinarray_iter.h>
 #include <tbx/type_malloc.h>
 
 #include <lio/blacklist.h>
@@ -75,12 +76,13 @@ gop_op_status_t touch_fn(void *arg, int id)
 
 int main(int argc, char **argv)
 {
-    int i, j, k, n, start_index, err, start_option, return_code;
-    char *ex_fname;
+    int i, start_index, start_option, return_code;
+    char *ex_fname, *path;
+    tbx_stdinarray_iter_t *it;
     gop_opque_t *q;
     gop_op_generic_t *gop;
     gop_op_status_t status;
-    lio_path_tuple_t *flist;
+    lio_path_tuple_t *tuple;
     char *error_table[] = { "", "ERROR Failed to update modify timestamp", "ERROR creating file" };
     FILE *fd;
 
@@ -142,60 +144,48 @@ int main(int argc, char **argv)
     if (exnode_data != NULL) free(exnode_data);
 
     //** Spawn the tasks
-    n = argc - start_index;
-    tbx_type_malloc(flist, lio_path_tuple_t, n);
-
     q = gop_opque_new();
     opque_start_execution(q);
-    i = 0;
     return_code = 0;
-    for (k=0; k<n; k++) {
-        flist[i] = lio_path_resolve(lio_gc->auto_translate, argv[k+start_index]);
-        if (flist[i].is_lio < 0) {
-            fprintf(stderr, "Unable to parse path: %s\n", argv[k+start_index]);
-            return_code = EINVAL;
-            continue;
+    it = tbx_stdinarray_iter_create(argc-start_index, (const char **)(argv+start_index));
+    while (1) {
+        path = tbx_stdinarray_iter_next(it);
+        if (path) {
+            tbx_type_malloc(tuple, lio_path_tuple_t, 1);
+            *tuple = lio_path_resolve(lio_gc->auto_translate, path);
+            if (tuple->is_lio < 0) {
+                fprintf(stderr, "Unable to parse path: %s\n", path);
+                free(path);
+                free(tuple);
+                return_code = EINVAL;
+                continue;
+            }
+            free(path);
+
+            gop = gop_tp_op_new(lio_gc->tpc_unlimited, NULL, touch_fn, tuple, NULL, 1);
+            gop_set_private(gop, tuple);
+            gop_opque_add(q, gop);
         }
 
-        gop = gop_tp_op_new(lio_gc->tpc_unlimited, NULL, touch_fn, (void *)&(flist[i]), NULL, 1);
-        gop_set_myid(gop, i);
-        log_printf(0, "gid=%d i=%d fname=%s\n", gop_id(gop), i, flist[i].path);
-        gop_opque_add(q, gop);
-
-        if (gop_opque_tasks_left(q) > lio_parallel_task_count) {
+        if ((gop_opque_tasks_left(q) > lio_parallel_task_count) || (path == NULL)) {
             gop = opque_waitany(q);
-            j = gop_get_myid(gop);
+            if (!gop) break;
+
             status = gop_get_status(gop);
+            tuple = gop_get_private(gop);
             if (status.op_status != OP_STATE_SUCCESS) {
-                info_printf(lio_ifd, 0, "Failed with file %s with: %s\n", flist[j].path, error_table[status.error_code]);
+                info_printf(lio_ifd, 0, "Failed with file %s with: %s\n", tuple->path, error_table[status.error_code]);
                 return_code = EIO;
             }
-            lio_path_release(&flist[j]);
+            lio_path_release(tuple);
+            free(tuple);
             gop_free(gop, OP_DESTROY);
-        }
-
-        i++;
-    }
-    n = i;
-
-    err = opque_waitall(q);
-    if (err != OP_STATE_SUCCESS) {
-        while ((gop = opque_get_next_failed(q)) != NULL) {
-            j = gop_get_myid(gop);
-            status = gop_get_status(gop);
-            info_printf(lio_ifd, 0, "Failed with file %s with: %s\n", flist[j].path, error_table[status.error_code]);
-            return_code = EIO;
         }
     }
 
     gop_opque_free(q, OP_DESTROY);
 
-    for(i=0; i<n; i++) {
-        lio_path_release(&(flist[i]));
-    }
-
-    free(flist);
-
+    tbx_stdinarray_iter_destroy(it);
     lio_shutdown();
 
     return(return_code);

--- a/src/lio/blacklist.c
+++ b/src/lio/blacklist.c
@@ -1,0 +1,143 @@
+/*
+   Copyright 2016 Vanderbilt University
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+//***********************************************************************
+// Routines for managing RID blacklisting
+//***********************************************************************
+
+#define _log_module_index 200
+
+#include <stdlib.h>
+#include <tbx/type_malloc.h>
+
+#include "blacklist.h"
+
+
+//***************************************************************
+// blacklist_remove_rs_added - Removes all the RIDs blakclisted due to the RS
+//***************************************************************
+
+void blacklist_remove_rs_added(lio_blacklist_t *bl)
+{
+    apr_ssize_t hlen;
+    apr_hash_index_t *hi;
+    lio_blacklist_ibp_rid_t *r;
+
+    apr_thread_mutex_lock(bl->lock);
+
+    //** Destroy all the blacklist RIDs
+    for (hi=apr_hash_first(NULL, bl->table); hi != NULL; hi = apr_hash_next(hi)) {
+        apr_hash_this(hi, NULL, &hlen, (void **)&r);
+        if (r->rs_added > 0) {
+            free(r->rid);
+            free(r);
+        }
+    }
+
+    apr_thread_mutex_unlock(bl->lock);
+}
+
+//***************************************************************
+// blacklist_add - Adds a blacklist RID
+//***************************************************************
+
+void blacklist_add(lio_blacklist_t *bl, char *rid_key, int rs_added, int do_lock)
+{
+    lio_blacklist_ibp_rid_t *bl_rid;
+
+    if (do_lock) apr_thread_mutex_lock(bl->lock);
+    if (apr_hash_get(bl->table, rid_key, APR_HASH_KEY_STRING) == NULL) {
+        log_printf(2, "Blacklisting RID=%s\n", rid_key);
+        tbx_type_malloc(bl_rid, lio_blacklist_ibp_rid_t, 1);
+        bl_rid->rid = strdup(rid_key);
+        bl_rid->recheck_time = apr_time_now() + ((rs_added == 0) ? bl->timeout : apr_time_from_sec(7200));
+        bl_rid->rs_added = rs_added;
+        apr_hash_set(bl->table, bl_rid->rid, APR_HASH_KEY_STRING, bl_rid);
+    }
+    if (do_lock) apr_thread_mutex_unlock(bl->lock);
+}
+
+//***************************************************************
+// blacklist_check - Checksto see if the RID is blacklisted
+//    Returns 1 if blacklisted and 0 otherwise
+//***************************************************************
+
+int blacklist_check(lio_blacklist_t *bl, char *rid_key, int do_lock)
+{
+    lio_blacklist_ibp_rid_t *bl_rid;
+    apr_time_t now;
+
+    now = apr_time_now();
+
+    if (do_lock) apr_thread_mutex_lock(bl->lock);
+    bl_rid = apr_hash_get(bl->table, rid_key, APR_HASH_KEY_STRING);
+    if (bl_rid) {
+        if (bl_rid->recheck_time < now) { //** Expired blacklist so undo it
+            log_printf(5, "EXPIRED rid=%s\n", bl_rid->rid);
+            apr_hash_set(bl->table, bl_rid->rid, APR_HASH_KEY_STRING, NULL);
+            free(bl_rid->rid);
+            free(bl_rid);
+            bl_rid = NULL;  //** No blacklisting
+        }
+    }
+    if (do_lock) apr_thread_mutex_unlock(bl->lock);
+
+    return((bl_rid == NULL) ? 0 : 1);
+}
+
+//***************************************************************
+// blacklist_destroy - Destroys a blacklist structure
+//***************************************************************
+
+void blacktbx_list_destroy(lio_blacklist_t *bl)
+{
+    apr_ssize_t hlen;
+    apr_hash_index_t *hi;
+    lio_blacklist_ibp_rid_t *r;
+
+    //** Destroy all the blacklist RIDs
+    for (hi=apr_hash_first(NULL, bl->table); hi != NULL; hi = apr_hash_next(hi)) {
+        apr_hash_this(hi, NULL, &hlen, (void **)&r);
+        free(r->rid);
+        free(r);
+    }
+
+    apr_pool_destroy(bl->mpool);
+    apr_thread_mutex_destroy(bl->lock);
+    free(bl);
+}
+
+//***************************************************************
+// blacklist_load - Loads and creates a blacklist structure
+//***************************************************************
+
+lio_blacklist_t *blacklist_load(tbx_inip_file_t *ifd, char *section)
+{
+    lio_blacklist_t *bl;
+
+    tbx_type_malloc_clear(bl, lio_blacklist_t, 1);
+
+    assert_result(apr_pool_create(&(bl->mpool), NULL), APR_SUCCESS);
+    apr_thread_mutex_create(&(bl->lock), APR_THREAD_MUTEX_DEFAULT, bl->mpool);
+    bl->table = apr_hash_make(bl->mpool);
+
+    bl->timeout = tbx_inip_get_integer(ifd, section, "timeout", apr_time_from_sec(120));
+    bl->min_bandwidth = tbx_inip_get_integer(ifd, section, "min_bandwidth", 5*1024*1024);  //** default ro 5MB
+    bl->min_io_time = tbx_inip_get_integer(ifd, section, "min_io_time", apr_time_from_sec(1));  //** default ro 5MB
+
+    return(bl);
+}
+

--- a/src/lio/blacklist.c
+++ b/src/lio/blacklist.c
@@ -42,6 +42,7 @@ void blacklist_remove_rs_added(lio_blacklist_t *bl)
     for (hi=apr_hash_first(NULL, bl->table); hi != NULL; hi = apr_hash_next(hi)) {
         apr_hash_this(hi, NULL, &hlen, (void **)&r);
         if (r->rs_added > 0) {
+            apr_hash_set(bl->table, r->rid, APR_HASH_KEY_STRING, NULL);
             free(r->rid);
             free(r);
         }

--- a/src/lio/blacklist.h
+++ b/src/lio/blacklist.h
@@ -26,6 +26,7 @@
 #include <apr_thread_mutex.h>
 #include <apr_time.h>
 #include <lio/blacklist.h>
+#include <tbx/iniparse.h>
 
 #include "ex3/types.h"
 
@@ -34,8 +35,9 @@ extern "C" {
 #endif
 
 struct lio_blacklist_ibp_rid_t {
-    char *rid;
-    apr_time_t recheck_time;
+    char *rid;                   //** RID blacklisted
+    int  rs_added;               //** RID was blacklisted by the Resource Service
+    apr_time_t recheck_time;     //** Recheck time
 };
 
 struct lio_blacklist_t {
@@ -46,6 +48,12 @@ struct lio_blacklist_t {
     apr_time_t min_io_time;
     apr_time_t timeout;
 };
+
+void blacklist_remove_rs_added(lio_blacklist_t *bl);
+void blacklist_add(lio_blacklist_t *bl, char *rid_key, int rs_added, int do_lock);
+int blacklist_check(lio_blacklist_t *bl, char *rid_key, int do_lock);
+void blacktbx_list_destroy(lio_blacklist_t *bl);
+lio_blacklist_t *blacklist_load(tbx_inip_file_t *ifd, char *section);
 
 #ifdef __cplusplus
 }

--- a/src/lio/ex3.c
+++ b/src/lio/ex3.c
@@ -331,10 +331,10 @@ ex_id_t exnode_exchange_get_default_view_id(lio_exnode_exchange_t *exp)
 }
 
 //*************************************************************************
-// lio_lio_exnode_exchange_text_parse - Parses a text based exnode and returns it
+// lio_exnode_exchange_text_parse - Parses a text based exnode and returns it
 //*************************************************************************
 
-lio_exnode_exchange_t *lio_lio_exnode_exchange_text_parse(char *text)
+lio_exnode_exchange_t *lio_exnode_exchange_text_parse(char *text)
 {
     lio_exnode_exchange_t *exp;
     tbx_inip_file_t *ifd;
@@ -374,7 +374,7 @@ lio_exnode_exchange_t *lio_exnode_exchange_load_file(char *fname)
     text[i+1] = '\0';
     fclose(fd);
 
-    return(lio_lio_exnode_exchange_text_parse(text));
+    return(lio_exnode_exchange_text_parse(text));
 }
 
 //*************************************************************************

--- a/src/lio/lio/ex3.h
+++ b/src/lio/lio/ex3.h
@@ -46,7 +46,7 @@ LIO_API void lio_exnode_destroy(lio_exnode_t *ex);
 LIO_API lio_exnode_exchange_t *lio_exnode_exchange_create(int type);
 LIO_API void lio_exnode_exchange_destroy(lio_exnode_exchange_t *exp);
 LIO_API lio_exnode_exchange_t *lio_exnode_exchange_load_file(char *fname);
-LIO_API lio_exnode_exchange_t *lio_lio_exnode_exchange_text_parse(char *text);
+LIO_API lio_exnode_exchange_t *lio_exnode_exchange_text_parse(char *text);
 LIO_API int lio_exnode_serialize(lio_exnode_t *ex, lio_exnode_exchange_t *exp);
 LIO_API gop_op_generic_t *lio_segment_copy_gop(gop_thread_pool_context_t *tpc, data_attr_t *da, lio_segment_rw_hints_t *rw_hints, lio_segment_t *src_seg, lio_segment_t *dest_seg, ex_off_t src_offset, ex_off_t dest_offset, ex_off_t len, ex_off_t bufsize, char *buffer, int do_truncate, int timoeut);
 LIO_API int lio_view_insert(lio_exnode_t *ex, lio_segment_t *view);
@@ -134,14 +134,14 @@ struct lio_inspect_args_t {
     int dev_row_replaced[128];
 };
 
-struct lio_lio_exnode_text_t {
+struct lio_exnode_text_t {
     char *text;
     tbx_inip_file_t *fd;
 };
 
 struct lio_exnode_exchange_t {
     lio_ex3_format_t type;
-    lio_lio_exnode_text_t text;
+    lio_exnode_text_t text;
 };
 
 #ifdef __cplusplus

--- a/src/lio/lio/ex3_fwd.h
+++ b/src/lio/lio/ex3_fwd.h
@@ -39,7 +39,7 @@ typedef struct lio_segment_t lio_segment_t;
 typedef lio_segment_t *(*lio_segment_create_fn_t)(void *arg);
 typedef struct lio_ex_header_t lio_ex_header_t;
 typedef struct lio_exnode_exchange_t lio_exnode_exchange_t;
-typedef struct lio_lio_exnode_text_t lio_lio_exnode_text_t;
+typedef struct lio_exnode_text_t lio_exnode_text_t;
 typedef int64_t ex_off_t;
 typedef uint64_t ex_id_t;
 typedef ibp_tbx_iovec_t ex_tbx_iovec_t;

--- a/src/lio/lio/lio.h
+++ b/src/lio/lio/lio.h
@@ -237,6 +237,7 @@ struct lio_cp_path_t {
     int obj_types;
     int max_spawn;
     int slow;
+    int force_dest_create;
     ex_off_t bufsize;
 };
 #ifdef __cplusplus

--- a/src/lio/lio/segment.h
+++ b/src/lio/lio/segment.h
@@ -37,7 +37,7 @@ typedef struct lio_segment_vtable_t lio_segment_vtable_t;
 typedef gop_op_generic_t *(*lio_segment_read_fn_t)(lio_segment_t *seg, data_attr_t *da, lio_segment_rw_hints_t *hints, int n_iov, ex_tbx_iovec_t *iov, tbx_tbuf_t *buffer, ex_off_t boff, int timeout);
 typedef gop_op_generic_t *(*lio_segment_write_fn_t)(lio_segment_t *seg, data_attr_t *da, lio_segment_rw_hints_t *hints, int n_iov, ex_tbx_iovec_t *iov, tbx_tbuf_t *buffer, ex_off_t boff, int timeout);
 typedef gop_op_generic_t *(*lio_segment_inspect_fn_t)(lio_segment_t *seg, data_attr_t *da, tbx_log_fd_t *fd, int mode, ex_off_t buffer_size, lio_inspect_args_t *args, int timeout);
-typedef gop_op_generic_t *(*lio_lio_segment_truncate_fn_t)(lio_segment_t *seg, data_attr_t *da, ex_off_t new_size, int timeout);
+typedef gop_op_generic_t *(*lio_segment_truncate_fn_t)(lio_segment_t *seg, data_attr_t *da, ex_off_t new_size, int timeout);
 typedef gop_op_generic_t *(*lio_segment_remove_fn_t)(lio_segment_t *seg, data_attr_t *da, int timeout);
 typedef gop_op_generic_t *(*lio_segment_flush_fn_t)(lio_segment_t *seg, data_attr_t *da, ex_off_t lo, ex_off_t hi, int timeout);
 typedef gop_op_generic_t *(*lio_segment_clone_fn_t)(lio_segment_t *seg, data_attr_t *da, lio_segment_t **clone, int mode, void *attr, int timeout);
@@ -80,7 +80,7 @@ struct lio_segment_vtable_t {
     lio_segment_read_fn_t read;
     lio_segment_write_fn_t write;
     lio_segment_inspect_fn_t inspect;
-    lio_lio_segment_truncate_fn_t truncate;
+    lio_segment_truncate_fn_t truncate;
     lio_segment_remove_fn_t remove;
     lio_segment_flush_fn_t flush;
     lio_segment_clone_fn_t clone;

--- a/src/lio/lio_config.c
+++ b/src/lio/lio_config.c
@@ -685,50 +685,6 @@ void lc_object_remove_unused(int remove_all_unused)
 }
 
 //***************************************************************
-// blacklist_destroy - Destroys a blacklist structure
-//***************************************************************
-
-void blacktbx_list_destroy(lio_blacklist_t *bl)
-{
-    apr_ssize_t hlen;
-    apr_hash_index_t *hi;
-    lio_blacklist_ibp_rid_t *r;
-
-    //** Destroy all the blacklist RIDs
-    for (hi=apr_hash_first(NULL, bl->table); hi != NULL; hi = apr_hash_next(hi)) {
-        apr_hash_this(hi, NULL, &hlen, (void **)&r);
-        free(r->rid);
-        free(r);
-    }
-
-    apr_pool_destroy(bl->mpool);
-    apr_thread_mutex_destroy(bl->lock);
-    free(bl);
-}
-
-//***************************************************************
-// blacklist_load - Loads and creates a blacklist structure
-//***************************************************************
-
-lio_blacklist_t *blacklist_load(tbx_inip_file_t *ifd, char *section)
-{
-    lio_blacklist_t *bl;
-
-    tbx_type_malloc_clear(bl, lio_blacklist_t, 1);
-
-    assert_result(apr_pool_create(&(bl->mpool), NULL), APR_SUCCESS);
-    apr_thread_mutex_create(&(bl->lock), APR_THREAD_MUTEX_DEFAULT, bl->mpool);
-    bl->table = apr_hash_make(bl->mpool);
-
-    bl->timeout = tbx_inip_get_integer(ifd, section, "timeout", apr_time_from_sec(120));
-    bl->min_bandwidth = tbx_inip_get_integer(ifd, section, "min_bandwidth", 5*1024*1024);  //** default ro 5MB
-    bl->min_io_time = tbx_inip_get_integer(ifd, section, "min_io_time", apr_time_from_sec(1));  //** default ro 5MB
-
-    return(bl);
-}
-
-
-//***************************************************************
 // lio_print_options - Prints the standard supported lio options
 //   Use "LIO_COMMON_OPTIONS" in the arg list
 //***************************************************************

--- a/src/lio/lio_config.c
+++ b/src/lio/lio_config.c
@@ -441,6 +441,12 @@ lio_path_tuple_t lio_path_resolve_base(char *lpath)
     int n, is_lio;
 
     is_lio = lio_parse_path(lpath, &pp_userid, &pp_section_name, &fname);
+    if (is_lio == -1) { //** Can't parse the path
+        memset(&tuple, 0, sizeof(tuple));
+        tuple.is_lio = is_lio;
+        return(tuple);
+    }
+
     userid = pp_userid;
     section_name = pp_section_name;
 

--- a/src/lio/lio_core_io.c
+++ b/src/lio/lio_core_io.c
@@ -437,7 +437,7 @@ gop_op_status_t lio_myopen_fn(void *arg, int id)
     }
 
     //** Load the exnode and get the default view ID
-    exp = lio_lio_exnode_exchange_text_parse(exnode);
+    exp = lio_exnode_exchange_text_parse(exnode);
     vid = exnode_exchange_get_default_view_id(exp);
     if (vid == 0) {  //** Make sure the vid is valid.
         log_printf(1, "ERROR loading exnode! fname=%s\n", op->path);

--- a/src/lio/lio_core_misc.c
+++ b/src/lio/lio_core_misc.c
@@ -51,7 +51,10 @@
 //  lio_parse_path - Parses a path ofthe form: user@service:/my/path
 //        The user and service are optional
 //
-//  Returns 1 if @: are encountered and 0 otherwise
+//  Returns:
+//     1 if @: are encountered
+//     0 if @: are missing
+//    -1 if the path can't be parsed.  Usually :@ or some perm
 //***********************************************************************
 
 int lio_parse_path(char *startpath, char **user, char **service, char **path)
@@ -67,6 +70,8 @@ int lio_parse_path(char *startpath, char **user, char **service, char **path)
             found = i;
             ptype = 1;
             break;
+        } else if (startpath[i] == ':') {  //** Should have an '@' first
+            return(-1);
         }
     }
 

--- a/src/lio/lio_core_os.c
+++ b/src/lio/lio_core_os.c
@@ -264,7 +264,7 @@ gop_op_status_t lio_create_object_fn(void *arg, int id)
         //** same segment being serialized/deserialized.
 
         //** Deserialize it
-        exp = lio_lio_exnode_exchange_text_parse(val[ex_key]);
+        exp = lio_exnode_exchange_text_parse(val[ex_key]);
         ex = lio_exnode_create();
         if (lio_exnode_deserialize(ex, exp, op->lc->ess_nocache) != 0) {
             log_printf(15, "ERROR parsing parent exnode src_path=%s\n", op->src_path);
@@ -433,7 +433,7 @@ gop_op_status_t lio_remove_object_fn(void *arg, int id)
     //** Only done for normal files.  No links or dirs
     if ((ex_remove == 1) && (ex_data != NULL)) {
         //** Deserialize it
-        exp = lio_lio_exnode_exchange_text_parse(ex_data);
+        exp = lio_exnode_exchange_text_parse(ex_data);
         ex = lio_exnode_create();
         if (lio_exnode_deserialize(ex, exp, op->lc->ess) != 0) {
             log_printf(15, "ERROR removing data for object fname=%s\n", op->src_path);
@@ -1461,7 +1461,7 @@ int lio_fsck_check_object(lio_config_t *lc, lio_creds_t *creds, char *path, int 
     //** to the global cache table cause there could be multiple copies of the
     //** same segment being serialized/deserialized.
     //** Deserialize it
-    exp = lio_lio_exnode_exchange_text_parse(val[ex_index]);
+    exp = lio_exnode_exchange_text_parse(val[ex_index]);
     ex = lio_exnode_create();
     if (lio_exnode_deserialize(ex, exp, lc->ess_nocache) != 0) {
         log_printf(15, "ERROR parsing parent exnode path=%s\n", path);

--- a/src/lio/lio_fuse_core.c
+++ b/src/lio/lio_fuse_core.c
@@ -1097,7 +1097,7 @@ void lfs_set_tape_attr(lio_fuse_t *lfs, char *fname, char *mytape_val, int tape_
         //** to the global cache table cause there could be multiple copies of the
         //** same segment being serialized/deserialized.
         //** Deserialize it
-        exp = lio_lio_exnode_exchange_text_parse(val[ex_key]);
+        exp = lio_exnode_exchange_text_parse(val[ex_key]);
         ex = lio_exnode_create();
         err = lio_exnode_deserialize(ex, exp, lfs->lc->ess_nocache);
         exnode_exchange_free(exp);

--- a/src/lio/lio_fuse_core.c
+++ b/src/lio/lio_fuse_core.c
@@ -701,7 +701,7 @@ int lfs_read(const char *fname, char *buf, size_t size, off_t off, struct fuse_f
 
     dt = apr_time_now() - now;
     dt /= APR_USEC_PER_SEC;
-    log_printf(1, "END fname=%s seg=" XIDT " size=" XOT " off=%zu nbytes=" XOT " dt=%lf\n", fname, segment_id(fd->fh->seg), t1, size, nbytes, dt);
+    log_printf(1, "END fname=%s seg=" XIDT " size=" XOT " off=%zu nbytes=" XOT " dt=%lf\n", fname, segment_id(fd->fh->seg), t1, t2, nbytes, dt);
     tbx_log_flush();
 
     return(nbytes);

--- a/src/lio/rs/simple.h
+++ b/src/lio/rs/simple.h
@@ -59,6 +59,7 @@ struct lio_rs_simple_priv_t {
     tbx_list_t *rid_table;
     lio_rss_rid_entry_t **random_array;
     lio_data_service_fn_t *ds;
+    lio_service_manager_t *ess;
     data_attr_t *da;
     apr_thread_mutex_t *lock;
     apr_thread_mutex_t *update_lock;

--- a/src/lio/segment.c
+++ b/src/lio/segment.c
@@ -320,7 +320,7 @@ gop_op_status_t segment_get_gop_func(void *arg, int id)
         total += got;
         log_printf(5, "sid=" XIDT " fwrite(wb,1," XOT ", sc->fd)=" XOT " total=" XOT "\n", segment_id(sc->src), wlen, got, total);
         if (wlen != got) {
-            log_printf(1, "ERROR from fwrite=%d  dest sid=" XIDT "\n", errno, segment_id(sc->src));
+            log_printf(1, "ERROR from fwrite=%d  dest sid=" XIDT "\n", errno, segment_id(sc->dest));
             status = gop_failure_status;
             gop_waitall(gop);
             gop_free(gop, OP_DESTROY);
@@ -334,7 +334,7 @@ gop_op_status_t segment_get_gop_func(void *arg, int id)
             err = gop_waitall(gop);
             gop_free(gop, OP_DESTROY);
             if (err != OP_STATE_SUCCESS) {
-                log_printf(1, "ERROR write(dseg=" XIDT ") failed! wpos=" XOT " len=" XOT "\n", segment_id(sc->dest), wpos, wlen);
+                log_printf(1, "ERROR read(seg=" XIDT ") failed! wpos=" XOT " len=" XOT "\n", segment_id(sc->src), wpos, wlen);
                 status = gop_failure_status;
                 goto fail;
             }

--- a/src/lio/segment/jerasure.c
+++ b/src/lio/segment/jerasure.c
@@ -1326,7 +1326,7 @@ tryagain:  //** We first try allowing blacklisting to proceed as normal and then
                         } else {  //** Recoverable
                             log_printf(5, "seg=" XIDT " recoverable write error off=" XOT " len= "XOT " n_parity=%d good=%d error_code=%d magic_used=%d index=%d magic_count[index]=%d\n",
                                        segment_id(sw->seg), sw->iov[slot].offset, sw->iov[slot].len, s->n_parity_devs, magic_count[index], op_status.error_code, magic_used, index, magic_count[index]);
-                            status.error_code = op_status.error_code;
+                            if (hard_error == 0) status.error_code = op_status.error_code;
                             soft_error = 1;
                             do_recover = 1;
                         }

--- a/src/lio/segment/lun.c
+++ b/src/lio/segment/lun.c
@@ -1621,7 +1621,7 @@ gop_op_status_t seglun_rw_op(lio_segment_t *seg, data_attr_t *da, lio_segment_rw
             dt_status = gop_get_status(gop);
             if (dt_status.op_status != OP_STATE_SUCCESS) bad_count++;
             dev = gop_get_myid(gop) % s->n_devices;
-            log_printf(1, "device=%d slot=%d time: %lf op_status=%d error_code=%d\n", dev, gop_get_myid(gop), dt, dt_status.op_status, dt_status.error_code);
+            log_printf(1, "device=%d slot=%d time: %lf op_status=%d error_code=%d gid=%d\n", dev, gop_get_myid(gop), dt, dt_status.op_status, dt_status.error_code, gop_id(gop));
             log_printf(5, "bl=%p\n", bl);
             //** Check if we need to do any blacklisting
             if ((dt_status.error_code != -1234) && (bl != NULL)) { //** Skip the blacklisted ops

--- a/src/toolbox/iniparse.c
+++ b/src/toolbox/iniparse.c
@@ -262,7 +262,6 @@ tbx_inip_group_t *_next_group(bfile_t *bfd)
             start++;  //** Move the starting point to the next character
 
             text = tbx_stk_string_trim(start); //** Trim the whitespace
-//        text = tbx_stk_string_token(start, " ", &last, &i);
             tbx_type_malloc(g, tbx_inip_group_t, 1);
             g->group = strdup(text);
             g->list = NULL;
@@ -339,20 +338,22 @@ void tbx_inip_destroy(tbx_inip_file_t *inip)
 }
 
 //***********************************************************************
-//  _find_key - Scans the group for the given key and returns the element
+//  _find_key - Scans the group for the given key and returns the last
+//       matching element
 //***********************************************************************
 
 tbx_inip_element_t *_find_key(tbx_inip_group_t *group, const char *name)
 {
-    tbx_inip_element_t *ele;
+    tbx_inip_element_t *ele, *found;
 
     if (group == NULL) return(NULL);
 
+    found = NULL;
     for (ele = group->list; ele != NULL; ele = ele->next) {
-        if (strcmp(ele->key, name) == 0) return(ele);
+        if (strcmp(ele->key, name) == 0) found = ele;
     }
 
-    return(NULL);
+    return(found);
 }
 
 //***********************************************************************
@@ -371,18 +372,20 @@ char *tbx_inip_find_key(tbx_inip_group_t *group, const char *name)
 
 
 //***********************************************************************
-//  inip_find_group - Scans the tree for the given group
+//  inip_find_group - Scans the tree for the given group and returns
+//      the last one encountered
 //***********************************************************************
 
 tbx_inip_group_t *tbx_inip_group_find(tbx_inip_file_t *inip, const char *name)
 {
-    tbx_inip_group_t *group;
+    tbx_inip_group_t *group, *found;
 
+    found = NULL;
     for (group = inip->tree; group != NULL; group = group->next) {
-        if (strcmp(group->group, name) == 0) return(group);
+        if (strcmp(group->group, name) == 0) found = group;
     }
 
-    return(NULL);
+    return(found);
 }
 
 //***********************************************************************
@@ -495,8 +498,6 @@ tbx_inip_file_t *inip_read_fd(FILE *fd)
 
         group = _next_group(&bfd);
     }
-
-
 
     if (bfd.curr != NULL) {
         fclose(bfd.curr->fd);

--- a/src/toolbox/stdinarray_iter.c
+++ b/src/toolbox/stdinarray_iter.c
@@ -46,8 +46,17 @@ struct tbx_stdinarray_iter_s {  //** Stdin/list iterator
     int argc;           //** Size of argv
     int current;        //** Current argv index
     int from_stdin;     //** Processing args from stdin.
+    int last_used;      //** Already processed the last argument
+    int last_used_hit;  //** Flags that the last arg has been used
+    int curr_last;      //** Current is the last arg
+    int next_last;      //** Next is the last arg
     const char **argv;  //** Array of paths
+    const char *last;   //** Last argument if available
+    char *curr;         //** Current element to be returned
+    char *next;         //** Element to return after curr
 };
+
+char *sa_next(tbx_stdinarray_iter_t *it);
 
 //*************************************************************************
 //  tbx_stdinarray_iter_create - Create stdin/list iterator
@@ -57,13 +66,74 @@ tbx_stdinarray_iter_t *tbx_stdinarray_iter_create(int argc, const char **argv)
 {
     tbx_stdinarray_iter_t *it;
 
-    tbx_type_malloc(it, tbx_stdinarray_iter_t, 1);
+    tbx_type_malloc_clear(it, tbx_stdinarray_iter_t, 1);
     it->argc = argc;
     it->argv = argv;
     it->current = 0;
     it->from_stdin = 0;
 
+    if (it->argc == 0) return(it);  //** Nothing left to do
+
+    //** check on the last arg
+    if (strcmp(it->argv[it->argc-1], SARRAY_STDIN) != 0) { //** Normal line
+        it->last = it->argv[argc-1];
+    }
+
+    //** Get the peek items
+    it->curr = sa_next(it);
+    if (it->last_used_hit) {
+        it->curr_last = 1;
+    } else {
+        it->next = sa_next(it);
+        if (it->last_used_hit) it->next_last = 1;
+    }
+
     return(it);
+}
+
+//*************************************************************************
+// tbx_stdinarray_iter_last - Returns the last argument if available.
+//     IF the last argument is "-" NULL is returned since it is
+//     impossible to tell from stdin without buffering.
+//
+//     Calling this routine also removes the last argument from being
+//     returned via the next() routine
+//*************************************************************************
+
+char *tbx_stdinarray_iter_last(tbx_stdinarray_iter_t *it)
+{
+    if (it->last_used == 0) {
+        it->argc--;
+        it->last_used = 1;
+    }
+
+    if (it->curr_last == 1) {
+        free(it->curr);
+        it->curr = NULL;
+    }
+    if (it->next_last == 1) {
+        free(it->next);
+        it->next = NULL;
+    }
+    return((it->last) ? strdup(it->last) : NULL);
+}
+
+//*************************************************************************
+//   tbx_stdinarray_iter_peek - Peeks ahead in the stream to see what
+//       will be returned in upcoming next() calls.
+//       You can only peek ahead 1 or 2 slots.  The data returned is 
+//       an internally managed string and should not be destroyed.
+//*************************************************************************
+
+char *tbx_stdinarray_iter_peek(tbx_stdinarray_iter_t *it, int ahead)
+{
+    if (ahead == 1) {
+        return(it->curr);
+    } else if (ahead == 2) {
+        return(it->next);
+    }
+
+    return(NULL);
 }
 
 //*************************************************************************
@@ -72,6 +142,8 @@ tbx_stdinarray_iter_t *tbx_stdinarray_iter_create(int argc, const char **argv)
 
 void tbx_stdinarray_iter_destroy(tbx_stdinarray_iter_t *it)
 {
+   if (it->curr) free(it->curr);
+   if (it->next) free(it->next);
    free(it);
 }
 
@@ -82,7 +154,7 @@ void tbx_stdinarray_iter_destroy(tbx_stdinarray_iter_t *it)
 //    NOTE:  The caller is responsible for destroying the return argument
 //*************************************************************************
 
-char *tbx_stdinarray_iter_next(tbx_stdinarray_iter_t *it)
+char *sa_next(tbx_stdinarray_iter_t *it)
 {
     char stmp[8192];
     char *p;
@@ -94,6 +166,7 @@ next_from_list:
         if (strcmp(it->argv[it->current], SARRAY_STDIN) != 0) { //** Normal line
             p = strdup(it->argv[it->current]);
             it->current++;
+            if (it->current >= it->argc) it->last_used_hit = 1;
             return(p);
         }
 
@@ -114,3 +187,21 @@ next_from_list:
     return(NULL);  //** Nothing left to do
 }
 
+//*************************************************************************
+//  tbx_stdinarray_iter_next - Returns the next path from either argv or stdin
+//    IF no arguments are left then NULL is returned.
+//
+//    NOTE:  The caller is responsible for destroying the return argument
+//*************************************************************************
+
+char *tbx_stdinarray_iter_next(tbx_stdinarray_iter_t *it)
+{
+    char *path;
+
+    path = it->curr;
+    it->curr = it->next;  it->curr_last = it->next_last;
+    it->next = sa_next(it);
+    it->next_last = ((it->curr_last == 0) && (it->last_used_hit == 1)) ? 1 : 0;
+
+    return(path);
+}

--- a/src/toolbox/tbx/stdinarray_iter.h
+++ b/src/toolbox/tbx/stdinarray_iter.h
@@ -31,7 +31,8 @@ typedef struct tbx_stdinarray_iter_s tbx_stdinarray_iter_t;
 TBX_API tbx_stdinarray_iter_t *tbx_stdinarray_iter_create(int argc, const char **argv);
 TBX_API void tbx_stdinarray_iter_destroy(tbx_stdinarray_iter_t *it);
 TBX_API char *tbx_stdinarray_iter_next(tbx_stdinarray_iter_t *it);
-
+TBX_API char *tbx_stdinarray_iter_last(tbx_stdinarray_iter_t *it);
+TBX_API char *tbx_stdinarray_iter_peek(tbx_stdinarray_iter_t *it, int ahead);
 #ifdef __cplusplus
 }
 #endif

--- a/test/ex_rw_test.c
+++ b/test/ex_rw_test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         printf("ex_rw_test LIO_COMMON_OPTIONS [-ex] [-s section]\n");
         lio_print_options(stdout);
         printf("     -ex        Print the final exnode to the screen before truncation\n");
-        printf("     -s section SEction in the config file to usse.  Defaults to %s.\n", section);
+        printf("     -section section SEction in the config file to usse.  Defaults to %s.\n", section);
         printf("\n");
         return(1);
     }
@@ -57,7 +57,6 @@ int main(int argc, char **argv)
     if (argc > 1) {
         do {
             start_option = i;
-
             if (strcmp(argv[i], "-ex") == 0) { //** Show the final exnode
                 i++;
                 print_exnode = 1;

--- a/test/mq_test.c
+++ b/test/mq_test.c
@@ -1214,19 +1214,27 @@ int main(int argc, char **argv)
     int i;
     int volatile start_option;  //** This disables optimizing the arg loop and getting a warning. 
     char v;
+    char *logfile;
+    int dlevel;
 
     if (argc < 2) {
-        printf("mq_test [-d log_level]\n");
+        printf("mq_test [-d log_level] [-log logfile]\n");
         return(0);
     }
 
+    dlevel = 0;
+    logfile = NULL;
     i = 1;
     do {
         start_option = i;
 
         if (strcmp(argv[i], "-d") == 0) { //** Enable debugging
             i++;
-            tbx_set_log_level(atol(argv[i]));
+            dlevel = atol(argv[i]);
+            i++;
+        } else if (strcmp(argv[i], "-log") == 0) { //** Log output file
+            i++;
+            logfile = argv[i];
             i++;
         } else if (strcmp(argv[i], "-h") == 0) { //** Print help
             printf("mq_test [-d log_level]\n");
@@ -1234,6 +1242,9 @@ int main(int argc, char **argv)
         }
     } while ((start_option < i) && (i<argc));
 
+    if (logfile != NULL) tbx_log_open(logfile, 0);
+    tbx_set_log_level(dlevel);
+        
     printf("log_level=%d\n", _log_level);
 
     gop_init_opque_system();

--- a/test/mqs_test.c
+++ b/test/mqs_test.c
@@ -188,7 +188,7 @@ gop_mq_context_t *client_make_context()
 {
     char *text_params = "[mq_context]\n"
                         "  min_conn=1\n"
-                        "  max_conn=4\n"
+                        "  max_conn=1\n"
                         "  min_threads=2\n"
                         "  max_threads=%d\n"
                         "  backlog_trigger=1000\n"
@@ -507,7 +507,7 @@ gop_mq_context_t *server_make_context()
 {
     char *text_params = "[mq_context]\n"
                         "  min_conn=1\n"
-                        "  max_conn=2\n"
+                        "  max_conn=1\n"
                         "  min_threads=2\n"
                         "  max_threads=%d\n"
                         "  backlog_trigger=10000\n"


### PR DESCRIPTION
This has all the fixes and issues resolved uncovered in the last month along with some notable features that should help performance and stability:

- Integration of RS RID state into the blacklisting framework.  This should hopefully greatly diminish long running jobs.
- Standardized handling of CLI args paths and taking arguments from stdin.
- Better sanity checking for LIO path names
- Sanity checking for missing INI sections.  It now prints a message to stderr and exits making it easier to debug config issues
- It now returns the last section or key found matching the request instead of the first.  You can still iterate over all sections and keys to get everything.  This makes it more natural when overriding included sections from other files.
- lio_cp does the write thing now when copying a directory to an new directory.
- Fix some lingering ZMQ bugs found after dropping CZMQ.  You can now use hostnames! instead of just IPs.